### PR TITLE
Add coverage configuration to omit setup.py and __init__.py from reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,3 +132,9 @@ ignore = [
 python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
+
+[tool.coverage.run]
+omit = [
+    "*/setup.py",
+    "*/__init__.py"
+]


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change adds a new section to configure the coverage tool to omit certain files from coverage reports.

Configuration updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R135-R140): Added a `[tool.coverage.run]` section to omit `setup.py` and `__init__.py` files from coverage reports.