### PR TITLE
137 modularize tradeoff model configs

### DIFF
--- a/ssms/config/_modelconfig/tradeoff.py
+++ b/ssms/config/_modelconfig/tradeoff.py
@@ -1,0 +1,97 @@
+"""Configuration for tradeoff models."""
+
+import cssm
+from ssms.basic_simulators import boundary_functions as bf
+
+
+def get_tradeoff_no_bias_config():
+    """Get configuration for tradeoff model without bias."""
+    return {
+        "name": "tradeoff_no_bias",
+        "params": ["vh", "vl1", "vl2", "a", "d", "t"],
+        "param_bounds": [
+            [-4.0, -4.0, -4.0, 0.3, 0.0, 0.0],
+            [4.0, 4.0, 4.0, 2.5, 1.0, 2.0],
+        ],
+        "boundary_name": "constant",
+        "boundary": bf.constant,
+        "n_params": 6,
+        "default_params": [0.0, 0.0, 0.0, 1.0, 0.5, 1.0],
+        "nchoices": 4,
+        "choices": [0, 1, 2, 3],
+        "n_particles": 1,
+        "simulator": cssm.ddm_flexbound_tradeoff,
+    }
+
+
+def get_tradeoff_angle_no_bias_config():
+    """Get configuration for tradeoff model with angle boundary and no bias."""
+    return {
+        "name": "tradeoff_angle_no_bias",
+        "params": ["vh", "vl1", "vl2", "a", "d", "t", "theta"],
+        "param_bounds": [
+            [-4.0, -4.0, -4.0, 0.3, 0.0, 0.0, -0.1],
+            [4.0, 4.0, 4.0, 2.5, 1.0, 2.0, 1.0],
+        ],
+        "boundary_name": "angle",
+        "boundary": bf.angle,
+        "boundary_multiplicative": False,
+        "n_params": 7,
+        "default_params": [0.0, 0.0, 0.0, 1.0, 0.5, 1.0, 0.0],
+        "nchoices": 4,
+        "choices": [0, 1, 2, 3],
+        "n_particles": 1,
+        "simulator": cssm.ddm_flexbound_tradeoff,
+    }
+
+
+def get_tradeoff_weibull_no_bias_config():
+    """Get configuration for tradeoff model with Weibull boundary and no bias."""
+    return {
+        "name": "tradeoff_weibull_no_bias",
+        "params": ["vh", "vl1", "vl2", "a", "d", "t", "alpha", "beta"],
+        "param_bounds": [
+            [-4.0, -4.0, -4.0, 0.3, 0.0, 0.0, 0.31, 0.31],
+            [4.0, 4.0, 4.0, 2.5, 1.0, 2.0, 4.99, 6.99],
+        ],
+        "boundary_name": "weibull_cdf",
+        "boundary": bf.weibull_cdf,
+        "boundary_multiplicative": True,
+        "n_params": 8,
+        "default_params": [0.0, 0.0, 0.0, 1.0, 0.5, 1.0, 2.5, 3.5],
+        "nchoices": 4,
+        "n_particles": 1,
+        "simulator": cssm.ddm_flexbound_tradeoff,
+    }
+
+
+def get_tradeoff_conflict_gamma_no_bias_config():
+    """Get configuration for tradeoff model with conflict gamma boundary and no bias."""
+    return {
+        "name": "tradeoff_conflict_gamma_no_bias",
+        "params": [
+            "vh",
+            "vl1",
+            "vl2",
+            "d",
+            "t",
+            "a",
+            "theta",
+            "scale",
+            "alphagamma",
+            "scalegamma",
+        ],
+        "param_bounds": [
+            [-4.0, -4.0, -4.0, 0.0, 0.0, 0.3, 0.0, 0.0, 1.1, 0.5],
+            [4.0, 4.0, 4.0, 1.0, 2.0, 2.5, 0.5, 5.0, 5.0, 5.0],
+        ],
+        "boundary_name": "conflict_gamma",
+        "boundary": bf.conflict_gamma,
+        "boundary_multiplicative": True,
+        "n_params": 10,
+        "default_params": [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0, 2, 2],
+        "nchoices": 4,
+        "choices": [0, 1, 2, 3],
+        "n_particles": 1,
+        "simulator": cssm.ddm_flexbound_tradeoff,
+    }

--- a/ssms/config/config.py
+++ b/ssms/config/config.py
@@ -23,6 +23,13 @@ import scipy.stats as sps  # type: ignore
 from ssms.basic_simulators import boundary_functions as bf
 from ssms.basic_simulators import drift_functions as df
 
+from ssms.config._modelconfig.tradeoff import (
+    get_tradeoff_no_bias_config,
+    get_tradeoff_angle_no_bias_config,
+    get_tradeoff_weibull_no_bias_config,
+    get_tradeoff_conflict_gamma_no_bias_config,
+)
+
 
 def boundary_config_to_function_params(boundary_config: dict) -> dict:
     """
@@ -1660,106 +1667,10 @@ model_config = {
         "n_particles": 1,
         "simulator": cssm.ddm_flexbound_mic2_ornstein,
     },
-    # -----
-    "tradeoff_no_bias": {
-        "name": "tradeoff_no_bias",
-        "params": ["vh", "vl1", "vl2", "a", "d", "t"],
-        "param_bounds": [
-            [-4.0, -4.0, -4.0, 0.3, 0.0, 0.0],
-            [4.0, 4.0, 4.0, 2.5, 1.0, 2.0],
-        ],
-        "boundary_name": "constant",
-        "boundary": bf.constant,
-        "n_params": 6,
-        "default_params": [0.0, 0.0, 0.0, 1.0, 0.5, 1.0],
-        "nchoices": 4,
-        "choices": [0, 1, 2, 3],
-        "n_particles": 1,
-        "simulator": cssm.ddm_flexbound_tradeoff,
-    },
-    "tradeoff_angle_no_bias": {
-        "name": "tradeoff_angle_no_bias",
-        "params": ["vh", "vl1", "vl2", "a", "d", "t", "theta"],
-        "param_bounds": [
-            [-4.0, -4.0, -4.0, 0.3, 0.0, 0.0, -0.1],
-            [4.0, 4.0, 4.0, 2.5, 1.0, 2.0, 1.0],
-        ],
-        "boundary_name": "angle",
-        "boundary": bf.angle,
-        "boundary_multiplicative": False,
-        "n_params": 7,
-        "default_params": [0.0, 0.0, 0.0, 1.0, 0.5, 1.0, 0.0],
-        "nchoices": 4,
-        "choices": [0, 1, 2, 3],
-        "n_particles": 1,
-        "simulator": cssm.ddm_flexbound_tradeoff,
-    },
-    "tradeoff_weibull_no_bias": {
-        "name": "tradeoff_weibull_no_bias",
-        "params": ["vh", "vl1", "vl2", "a", "d", "t", "alpha", "beta"],
-        "param_bounds": [
-            [-4.0, -4.0, -4.0, 0.3, 0.0, 0.0, 0.31, 0.31],
-            [4.0, 4.0, 4.0, 2.5, 1.0, 2.0, 4.99, 6.99],
-        ],
-        "boundary_name": "weibull_cdf",
-        "boundary": bf.weibull_cdf,
-        "boundary_multiplicative": True,
-        "n_params": 8,
-        "default_params": [0.0, 0.0, 0.0, 1.0, 0.5, 1.0, 2.5, 3.5],
-        "nchoices": 4,
-        "n_particles": 1,
-        "simulator": cssm.ddm_flexbound_tradeoff,
-    },
-    "tradeoff_conflict_gamma_no_bias": {
-        "name": "tradeoff_conflict_gamma_no_bias",
-        "params": [
-            "vh",
-            "vl1",
-            "vl2",
-            "d",
-            "t",
-            "a",
-            "theta",
-            "scale",
-            "alphagamma",
-            "scalegamma",
-        ],
-        "param_bounds": [
-            [-4.0, -4.0, -4.0, 0.0, 0.0, 0.3, 0.0, 0.0, 1.1, 0.5],
-            [4.0, 4.0, 4.0, 1.0, 2.0, 2.5, 0.5, 5.0, 5.0, 5.0],
-        ],
-        "boundary_name": "conflict_gamma",
-        "boundary": bf.conflict_gamma,
-        "boundary_multiplicative": True,
-        "n_params": 10,
-        "default_params": [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0, 2, 2],
-        "nchoices": 4,
-        "choices": [0, 1, 2, 3],
-        "n_particles": 1,
-        "simulator": cssm.ddm_flexbound_tradeoff,
-    },
-    # "glob": {
-    #     "name": "glob",
-    #     "params": ["v", "a", "z", "alphar", "g", "t", "theta"],
-    #     "param_bounds": [
-    #         [-3.0, 0.3, 0.15, 1.0, -1.0, 1e-5, 0.0],
-    #         [3.0, 2.0, 0.85, 2.0, 1.0, 2.0, 1.45],
-    #     ],
-    #     "n_params": 7,
-    #     "default_params": [0.0, 1.0, 0.5, 2.0, 0.0, 1.0, 2.5, 3.5],
-    #     "hddm_include": ["z", "alphar", "g", "theta"],
-    #     "nchoices": 2,
-    #     "boundary_name": "angle",
-    #     "boundary": bf.angle,
-    #     "boundary_multiplicative": False,
-    #     "components": {
-    #         "names": ["g", "alphar", "theta"],
-    #         "off_values": np.float32(np.array([0, 1, 0])),
-    #         "probabilities": np.array([1 / 3, 1 / 3, 1 / 3]),
-    #         "labels": np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
-    #         "n_components": 3,
-    #     },
-    # },
+    "tradeoff_no_bias": get_tradeoff_no_bias_config(),
+    "tradeoff_angle_no_bias": get_tradeoff_angle_no_bias_config(),
+    "tradeoff_weibull_no_bias": get_tradeoff_weibull_no_bias_config(),
+    "tradeoff_conflict_gamma_no_bias": get_tradeoff_conflict_gamma_no_bias_config(),
 }
 
 model_config["weibull_cdf"] = model_config["weibull"].copy()


### PR DESCRIPTION
This pull request includes changes to the configuration of tradeoff models in the `ssms` package. The changes primarily involve moving the configuration details for various tradeoff models into separate functions and updating the main configuration file to use these functions.

Changes to tradeoff model configurations:

* [`ssms/config/_modelconfig/tradeoff.py`](diffhunk://#diff-9593105c06f76444f2cfbe70bff958e707f8d8a6813a2c5f7faf0a6ffb79957bR1-R97): Added new functions to define configurations for tradeoff models without bias, with angle boundary, with Weibull boundary, and with conflict gamma boundary.

Updates to main configuration file:

* [`ssms/config/config.py`](diffhunk://#diff-4abfaa992dfbb8d77d807ff7d58cffab97a44b2929dc284ac7e4b1430030f423R26-R32): Imported the new tradeoff configuration functions and updated the model configuration dictionary to use these functions instead of hardcoded configurations. [[1]](diffhunk://#diff-4abfaa992dfbb8d77d807ff7d58cffab97a44b2929dc284ac7e4b1430030f423R26-R32) [[2]](diffhunk://#diff-4abfaa992dfbb8d77d807ff7d58cffab97a44b2929dc284ac7e4b1430030f423L1663-R1673)