### PR TITLE
166 add workflow for testing lanfactory

### DIFF
--- a/.github/workflows/test_lanfactory.yml
+++ b/.github/workflows/test_lanfactory.yml
@@ -6,6 +6,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.11", "3.12"]
+
     steps:
       - name: Checkout current repo
         uses: actions/checkout@v4
@@ -21,7 +26,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: ["3.11", "3.12"]
+          python-version: ${{ matrix.python-version }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/test_lanfactory.yml
+++ b/.github/workflows/test_lanfactory.yml
@@ -1,0 +1,43 @@
+name: Test with LANfactory
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout current repo
+      uses: actions/checkout@v4
+      with:
+        path: ssm-simulators
+
+    - name: Checkout LANfactory
+      uses: actions/checkout@v4
+      with:
+        repository: lnccbrown/LANfactory
+        path: LANfactory
+
+    - name: Set up Python 3
+      uses: actions/setup-python@v5
+      with:
+        python-version: ["3.11", "3.12"]
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: "0.7.6"
+        enable-cache: true
+        cache-dependency-glob: "pyproject.toml uv.lock"
+
+    - name: Install current repo into LANfactory with uv
+      run: |
+        cd LANfactory
+        uv remove ssm-simulators
+        uv add ../ssm-simulators
+        uv sync --all-groups
+
+    - name: Run LANfactory tests
+      run: |
+        cd LANfactory
+        uv run pytest

--- a/.github/workflows/test_lanfactory.yml
+++ b/.github/workflows/test_lanfactory.yml
@@ -7,37 +7,37 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout current repo
-      uses: actions/checkout@v4
-      with:
-        path: ssm-simulators
+      - name: Checkout current repo
+        uses: actions/checkout@v4
+        with:
+          path: ssm-simulators
 
-    - name: Checkout LANfactory
-      uses: actions/checkout@v4
-      with:
-        repository: lnccbrown/LANfactory
-        path: LANfactory
+      - name: Checkout LANfactory
+        uses: actions/checkout@v4
+        with:
+          repository: lnccbrown/LANfactory
+          path: LANfactory
 
-    - name: Set up Python 3
-      uses: actions/setup-python@v5
-      with:
-        python-version: ["3.11", "3.12"]
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: ["3.11", "3.12"]
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v6
-      with:
-        version: "0.7.6"
-        enable-cache: true
-        cache-dependency-glob: "pyproject.toml uv.lock"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.7.6"
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml uv.lock"
 
-    - name: Install current repo into LANfactory with uv
-      run: |
-        cd LANfactory
-        uv remove ssm-simulators
-        uv add ../ssm-simulators
-        uv sync --all-groups
+      - name: Install current repo into LANfactory with uv
+        run: |
+          cd LANfactory
+          uv remove ssm-simulators
+          uv add ../ssm-simulators
+          uv sync --all-groups
 
-    - name: Run LANfactory tests
-      run: |
-        cd LANfactory
-        uv run pytest
+      - name: Run LANfactory tests
+        run: |
+          cd LANfactory
+          uv run pytest


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to integrate testing with the LANfactory framework. The workflow ensures compatibility across multiple Python versions and automates the setup and testing process for the repository.

### New GitHub Actions Workflow:
* `.github/workflows/test_lanfactory.yml`: Added a new workflow named "Test with LANfactory" that runs on `push` and `pull_request` events. It:
  - Tests the repository with Python versions 3.11 and 3.12.
  - Checks out both the current repository and the LANfactory repository.
  - Sets up Python and installs dependencies using `uv`.
  - Installs the current repository into LANfactory and synchronizes dependencies.
  - Executes LANfactory tests using `pytest`.