### PR TITLE
Fix setuppy for cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pathos >= 0.3.0",
     "numpy>=2.0",
     "typer>=0.15.3",
+    "pyyaml>=6.0.2",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
-import numpy  # noqa: D100
-from setuptools import Extension, setup
+from setuptools import setup, Extension, find_packages
+import numpy
 
+# Try to build with Cython if available
 try:
     from Cython.Build import cythonize
-
     ext_modules = cythonize(
         [Extension("cssm", ["src/cssm.pyx"], language="c++")],
         compiler_directives={"language_level": "3"},
@@ -11,14 +11,31 @@ try:
 except ImportError:
     ext_modules = [Extension("cssm", ["src/cssm.pyx"], language="c++")]
 
+# Use find_packages to automatically discover all packages
+packages = find_packages(include=['ssms', 'ssms.*'])
+
 setup(
-    packages=[
-        "ssms",
-        "ssms.basic_simulators",
-        "ssms.config",
-        "ssms.dataset_generators",
-        "ssms.support_utils",
-    ],
+    name="ssm-simulators",
+    version="0.8.3",
+    packages=packages,
+    package_data={
+        'ssms': ['**/*.py', '**/*.pyx', '**/*.pxd', '**/*.so', '**/*.pyd'],
+    },
+    include_package_data=True,
     include_dirs=[numpy.get_include()],
     ext_modules=ext_modules,
+    install_requires=[
+        'numpy',
+        'pandas',
+        'scipy',
+        'matplotlib',
+        'tqdm',
+        'pyyaml',
+        'typer',
+    ],
+    entry_points={
+        'console_scripts': [
+            'generate=ssms.generate:main',
+        ],
+    },
 )


### PR DESCRIPTION
Refactor `setup.py` to use `find_packages`, define package metadata, and include an entry point for a console script. This fixes circular import errors when using the CLI for data generation.

### `setup.py` improvements:

* Replaced manual listing of packages with `find_packages` to automatically discover all sub-packages in the `ssms` module.
* Added metadata fields such as `name` and `version` to define the package more clearly.
* Included `install_requires` to specify required dependencies for the package installation, ensuring all necessary libraries are installed.
* Added `entry_points` to define a console script (`generate=ssms.generate:main`) for easier command-line execution of the `generate` functionality.
* 
### Dependency updates:

* Added `pyyaml>=6.0.2` to the dependencies list in `pyproject.toml` to support YAML processing.

