### PR TITLE
V0.10.2 serial data generation fix deps build wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -29,6 +29,7 @@ jobs:
           CIBW_ARCHS_LINUX: auto64
           CIBW_ARCHS_WINDOWS: auto64
           CIBW_BUILD_FRONTEND: build
+          CIBW_BUILD_VERBOSITY: 3
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -16,8 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -25,7 +25,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.23.3
         env:
           CIBW_BUILD: cp310-* cp311-* cp312-*
-          CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_LINUX: auto64
           CIBW_ARCHS_WINDOWS: auto64
           CIBW_BUILD_FRONTEND: build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ssm-simulators"
-version = "0.10.1"
+version = "0.10.2"
 description = "SSMS is a package collecting simulators and training data generators for cognitive science, neuroscience, and approximate bayesian computation"
 authors = [
     { name = "Alexander Fengler", email = "alexander_fengler@brown.edu" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "cython >= 0.29.23",
     "scipy >= 1.6.3",
     "pandas >= 1.0.0",
     "matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ packages = find_packages(include=["ssms", "ssms.*"])
 
 setup(
     name="ssm-simulators",
-    version="0.10.1",
+    version="0.10.2",
     packages=packages,
     package_data={
         "ssms": ["**/*.py", "**/*.pyx", "**/*.pxd", "**/*.so", "**/*.pyd"],

--- a/ssms/__init__.py
+++ b/ssms/__init__.py
@@ -4,6 +4,6 @@ from . import dataset_generators
 from . import config
 from . import support_utils
 
-__version__ = "0.10.1"  # importlib.metadata.version(__package__ or __name__)
+__version__ = "0.10.2"  # importlib.metadata.version(__package__ or __name__)
 
 __all__ = ["basic_simulators", "dataset_generators", "config", "support_utils"]


### PR DESCRIPTION
This pull request includes updates to the build workflow and dependency configurations. The most notable changes involve adjustments to macOS architecture settings in the CI workflow and the removal of the `cython` dependency from the `pyproject.toml` file.

### Build workflow updates:
* [`.github/workflows/build_wheels.yml`](diffhunk://#diff-52d0610b43ce35e44510ae2d15d70668334378b01c1bdc774159cd3a33b71728L19-R19): Removed `macos-13` and `macos-14` architecture comments and adjusted `CIBW_ARCHS_MACOS` to exclude `universal2`, leaving only `x86_64` and `arm64`. [[1]](diffhunk://#diff-52d0610b43ce35e44510ae2d15d70668334378b01c1bdc774159cd3a33b71728L19-R19) [[2]](diffhunk://#diff-52d0610b43ce35e44510ae2d15d70668334378b01c1bdc774159cd3a33b71728L29-R28)

### Dependency updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L16): Removed `cython >= 0.29.23` from the list of dependencies.