### PR TITLE
Add Ornstein model configurations and integrate into main config

### DIFF
--- a/ssms/config/_modelconfig/ornstein.py
+++ b/ssms/config/_modelconfig/ornstein.py
@@ -1,0 +1,41 @@
+"""Ornstein models configurations."""
+
+import cssm
+from ssms.basic_simulators import boundary_functions as bf
+
+
+def get_ornstein_config():
+    """Get the configuration for the Ornstein model."""
+    return {
+        "name": "ornstein",
+        "params": ["v", "a", "z", "g", "t"],
+        "param_bounds": [[-2.0, 0.3, 0.1, -1.0, 1e-3], [2.0, 3.0, 0.9, 1.0, 2]],
+        "boundary_name": "constant",
+        "boundary": bf.constant,
+        "n_params": 5,
+        "default_params": [0.0, 1.0, 0.5, 0.0, 1e-3],
+        "nchoices": 2,
+        "choices": [-1, 1],
+        "n_particles": 1,
+        "simulator": cssm.ornstein_uhlenbeck,
+    }
+
+
+def get_ornstein_angle_config():
+    """Get the configuration for the Ornstein angle model."""
+    return {
+        "name": "ornstein_angle",
+        "params": ["v", "a", "z", "g", "t", "theta"],
+        "param_bounds": [
+            [-2.0, 0.3, 0.1, -1.0, 1e-3, -0.1],
+            [2.0, 3.0, 0.9, 1.0, 2, 1.3],
+        ],
+        "boundary_name": "angle",
+        "boundary": bf.angle,
+        "n_params": 6,
+        "default_params": [0.0, 1.0, 0.5, 0.0, 1e-3, 0.1],
+        "nchoices": 2,
+        "choices": [-1, 1],
+        "n_particles": 1,
+        "simulator": cssm.ornstein_uhlenbeck,
+    }

--- a/ssms/config/config.py
+++ b/ssms/config/config.py
@@ -77,6 +77,11 @@ from ssms.config._modelconfig.dev_rlwm_lba import (
     get_dev_rlwm_lba_race_v2_config,
 )
 
+from ssms.config._modelconfig.ornstein import (
+    get_ornstein_config,
+    get_ornstein_angle_config,
+)
+
 
 def boundary_config_to_function_params(config: dict) -> dict:
     """
@@ -222,35 +227,8 @@ model_config = {
         "n_particles": 1,
         "simulator": cssm.ddm_flex,
     },
-    "ornstein": {
-        "name": "ornstein",
-        "params": ["v", "a", "z", "g", "t"],
-        "param_bounds": [[-2.0, 0.3, 0.1, -1.0, 1e-3], [2.0, 3.0, 0.9, 1.0, 2]],
-        "boundary_name": "constant",
-        "boundary": bf.constant,
-        "n_params": 5,
-        "default_params": [0.0, 1.0, 0.5, 0.0, 1e-3],
-        "nchoices": 2,
-        "choices": [-1, 1],
-        "n_particles": 1,
-        "simulator": cssm.ornstein_uhlenbeck,
-    },
-    "ornstein_angle": {
-        "name": "ornstein_angle",
-        "params": ["v", "a", "z", "g", "t", "theta"],
-        "param_bounds": [
-            [-2.0, 0.3, 0.1, -1.0, 1e-3, -0.1],
-            [2.0, 3.0, 0.9, 1.0, 2, 1.3],
-        ],
-        "boundary_name": "angle",
-        "boundary": bf.angle,
-        "n_params": 6,
-        "default_params": [0.0, 1.0, 0.5, 0.0, 1e-3, 0.1],
-        "nchoices": 2,
-        "choices": [-1, 1],
-        "n_particles": 1,
-        "simulator": cssm.ornstein_uhlenbeck,
-    },
+    "ornstein": get_ornstein_config(),
+    "ornstein_angle": get_ornstein_angle_config(),
     "race_2": get_race_2_config(),
     "race_no_bias_2": get_race_no_bias_2_config(),
     "race_no_z_2": get_race_no_z_2_config(),


### PR DESCRIPTION
This pull request refactors the configuration setup for the Ornstein models by moving their definitions into a separate module and replacing inline configurations with function calls. This change improves modularity and maintainability of the codebase.

### Modularization of Ornstein Model Configurations:

* **New module for Ornstein configurations**: Added a new file, `ssms/config/_modelconfig/ornstein.py`, containing functions `get_ornstein_config` and `get_ornstein_angle_config` to define configurations for the Ornstein and Ornstein angle models.
* **Import configurations**: Updated `ssms/config/config.py` to import the new configuration functions from the `ornstein` module.

### Refactoring of Configuration Usage:

* **Replaced inline configurations**: In `ssms/config/config.py`, replaced the inline definitions of `ornstein` and `ornstein_angle` configurations with calls to `get_ornstein_config` and `get_ornstein_angle_config`, respectively. This reduces duplication and centralizes the configuration logic.