### PR TITLE
Add model registration functionality and update model configurations

### DIFF
--- a/ssms/config/_modelconfig/angle.py
+++ b/ssms/config/_modelconfig/angle.py
@@ -2,8 +2,9 @@
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
+from ssms.config.registry import register_model
 
-
+@register_model("angle")
 def get_angle_config():
     """Get the configuration for the Angle model."""
     return {

--- a/ssms/config/_modelconfig/ddm.py
+++ b/ssms/config/_modelconfig/ddm.py
@@ -2,8 +2,9 @@
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
+from ssms.config.registry import register_model
 
-
+@register_model("ddm")
 def get_ddm_config():
     """Get the configuration for the DDM model."""
     return {

--- a/ssms/config/_modelconfig/ddm_par2.py
+++ b/ssms/config/_modelconfig/ddm_par2.py
@@ -2,8 +2,10 @@
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
+from ssms.config.registry import register_model
 
 
+@register_model("ddm_par2")
 def get_ddm_par2_config():
     return {
         "name": "ddm_par2",
@@ -23,6 +25,7 @@ def get_ddm_par2_config():
     }
 
 
+@register_model("ddm_par2_no_bias")
 def get_ddm_par2_no_bias_config():
     return {
         "name": "ddm_par2_no_bias",
@@ -39,6 +42,7 @@ def get_ddm_par2_no_bias_config():
     }
 
 
+@register_model("ddm_par2_conflict_gamma_no_bias")
 def get_ddm_par2_conflict_gamma_no_bias_config():
     return {
         "name": "ddm_par2_conflict_gamma_no_bias",
@@ -68,6 +72,7 @@ def get_ddm_par2_conflict_gamma_no_bias_config():
     }
 
 
+@register_model("ddm_par2_angle_no_bias")
 def get_ddm_par2_angle_no_bias_config():
     return {
         "name": "ddm_par2_angle_no_bias",
@@ -88,6 +93,7 @@ def get_ddm_par2_angle_no_bias_config():
     }
 
 
+@register_model("ddm_par2_weibull_no_bias")
 def get_ddm_par2_weibull_no_bias_config():
     return {
         "name": "ddm_par2_weibull_no_bias",

--- a/ssms/config/_modelconfig/ddm_random.py
+++ b/ssms/config/_modelconfig/ddm_random.py
@@ -6,8 +6,9 @@ import scipy.stats as sps
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
+from ssms.config.registry import register_model
 
-
+@register_model("ddm_st")
 def get_ddm_st_config():
     """Get configuration for DDM with random non-decision time."""
     return {
@@ -36,7 +37,7 @@ def get_ddm_st_config():
         },
     }
 
-
+@register_model("ddm_truncnormt")
 def get_ddm_truncnormt_config():
     """Get configuration for DDM with truncated normal non-decision time."""
     return {
@@ -70,7 +71,7 @@ def get_ddm_truncnormt_config():
         },
     }
 
-
+@register_model("ddm_rayleight")
 def get_ddm_rayleight_config():
     """Get configuration for DDM with Rayleigh non-decision time."""
     return {
@@ -102,7 +103,7 @@ def get_ddm_rayleight_config():
         },
     }
 
-
+@register_model("ddm_sdv")
 def get_ddm_sdv_config():
     """Get configuration for DDM with random drift rate."""
     return {

--- a/ssms/config/_modelconfig/ddm_seq2.py
+++ b/ssms/config/_modelconfig/ddm_seq2.py
@@ -2,8 +2,10 @@
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
+from ssms.config.registry import register_model
 
 
+@register_model("ddm_seq2")
 def get_ddm_seq2_config():
     """Get the configuration for the DDM seq2 model."""
     return {
@@ -24,6 +26,7 @@ def get_ddm_seq2_config():
     }
 
 
+@register_model("ddm_seq2_no_bias")
 def get_ddm_seq2_no_bias_config():
     """Get the configuration for the DDM seq2 no bias model."""
     return {
@@ -41,6 +44,7 @@ def get_ddm_seq2_no_bias_config():
     }
 
 
+@register_model("ddm_seq2_conflict_gamma_no_bias")
 def get_ddm_seq2_conflict_gamma_no_bias_config():
     """Get the configuration for the DDM seq2 conflict gamma no bias model."""
     return {
@@ -71,6 +75,7 @@ def get_ddm_seq2_conflict_gamma_no_bias_config():
     }
 
 
+@register_model("ddm_seq2_angle_no_bias")
 def get_ddm_seq2_angle_no_bias_config():
     """Get the configuration for the DDM seq2 angle no bias model."""
     return {
@@ -92,6 +97,7 @@ def get_ddm_seq2_angle_no_bias_config():
     }
 
 
+@register_model("ddm_seq2_weibull_no_bias")
 def get_ddm_seq2_weibull_no_bias_config():
     """Get the configuration for the DDM seq2 weibull no bias model."""
     return {

--- a/ssms/config/_modelconfig/dev_rlwm_lba.py
+++ b/ssms/config/_modelconfig/dev_rlwm_lba.py
@@ -2,8 +2,10 @@
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
+from ssms.config.registry import register_model
 
 
+@register_model("dev_rlwm_lba_pw_v1")
 def get_dev_rlwm_lba_pw_v1_config():
     """Get configuration for RLWM LBA pairwise v1 model."""
     return {
@@ -33,6 +35,7 @@ def get_dev_rlwm_lba_pw_v1_config():
     }
 
 
+@register_model("dev_rlwm_lba_race_v1")
 def get_dev_rlwm_lba_race_v1_config():
     """Get configuration for RLWM LBA race v1 model."""
     return {
@@ -63,6 +66,7 @@ def get_dev_rlwm_lba_race_v1_config():
     }
 
 
+@register_model("dev_rlwm_lba_race_v2")
 def get_dev_rlwm_lba_race_v2_config():
     """Get configuration for RLWM LBA race v2 model."""
     return {

--- a/ssms/config/_modelconfig/full_ddm.py
+++ b/ssms/config/_modelconfig/full_ddm.py
@@ -5,8 +5,10 @@ import scipy.stats as sps  # type: ignore
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
+from ssms.config.registry import register_model
 
 
+@register_model("full_ddm")
 def get_full_ddm_config():
     """Get the configuration for the Full DDM model."""
     return {
@@ -27,6 +29,7 @@ def get_full_ddm_config():
     }
 
 
+@register_model("full_ddm_rv")
 def get_full_ddm_rv_config():
     """Get configuration for full DDM with random variables."""
     return {

--- a/ssms/config/_modelconfig/gamma_drift.py
+++ b/ssms/config/_modelconfig/gamma_drift.py
@@ -2,8 +2,10 @@
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf, drift_functions as df
+from ssms.config.registry import register_model
 
 
+@register_model("gamma_drift")
 def get_gamma_drift_config():
     """Get the configuration for the Gamma drift model."""
     return {
@@ -25,7 +27,7 @@ def get_gamma_drift_config():
         "simulator": cssm.ddm_flex,
     }
 
-
+@register_model("gamma_drift_angle")
 def get_gamma_drift_angle_config():
     """Get the configuration for the Gamma drift angle model."""
     return {

--- a/ssms/config/_modelconfig/lba.py
+++ b/ssms/config/_modelconfig/lba.py
@@ -2,8 +2,10 @@
 
 from ssms.basic_simulators import boundary_functions as bf
 import cssm
+from ssms.config.registry import register_model
 
 
+@register_model("lba2")
 def get_lba2_config():
     """Get configuration for LBA2 model."""
     return {
@@ -21,6 +23,7 @@ def get_lba2_config():
     }
 
 
+@register_model("lba3")
 def get_lba3_config():
     """Get configuration for LBA3 model."""
     return {
@@ -38,6 +41,7 @@ def get_lba3_config():
     }
 
 
+@register_model("lba_3_vs_constraint")
 def get_lba_3_vs_constraint_config():
     """Get configuration for LBA3 with vs constraint model."""
     return {
@@ -56,6 +60,7 @@ def get_lba_3_vs_constraint_config():
     }
 
 
+@register_model("lba_angle_3_vs_constraint")
 def get_lba_angle_3_vs_constraint_config():
     """Get configuration for LBA angle 3 vs constraint model."""
     return {
@@ -73,7 +78,7 @@ def get_lba_angle_3_vs_constraint_config():
         "simulator": cssm.lba_angle,
     }
 
-
+@register_model("lba_angle_3")
 def get_lba_angle_3_config():
     """Get configuration for LBA angle 3 model without vs constraints."""
     return {

--- a/ssms/config/_modelconfig/lca.py
+++ b/ssms/config/_modelconfig/lca.py
@@ -2,8 +2,10 @@
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
+from ssms.config.registry import register_model
 
 
+@register_model("lca_3")
 def get_lca_3_config():
     """Get configuration for LCA3 model."""
     return {
@@ -23,6 +25,7 @@ def get_lca_3_config():
     }
 
 
+@register_model("lca_3_no_z3")
 def get_lca_no_z_3_config():
     """Get configuration for LCA3 model without bias."""
     return {
@@ -43,6 +46,7 @@ def get_lca_no_z_3_config():
     }
 
 
+@register_model("lca_4")
 def get_lca_4_config():
     """Get configuration for LCA4 model."""
     return {
@@ -76,6 +80,7 @@ def get_lca_4_config():
     }
 
 
+@register_model("lca_4_no_z_4")
 def get_lca_no_z_4_config():
     """Get configuration for LCA4 model without bias."""
     return {
@@ -96,6 +101,7 @@ def get_lca_no_z_4_config():
     }
 
 
+@register_model("lca_no_z_angle_4")
 def get_lca_no_z_angle_4_config():
     """Get configuration for LCA4 model with angle boundary and no bias."""
     return {
@@ -116,6 +122,7 @@ def get_lca_no_z_angle_4_config():
     }
 
 
+@register_model("lca_no_bias_3")
 def get_lca_no_bias_3_config():
     return {
         "name": "lca_no_bias_3",
@@ -135,6 +142,7 @@ def get_lca_no_bias_3_config():
     }
 
 
+@register_model("lca_no_bias_angle_3")
 def get_lca_no_bias_angle_3_config():
     return {
         "name": "lca_no_bias_angle_3",
@@ -154,6 +162,7 @@ def get_lca_no_bias_angle_3_config():
     }
 
 
+@register_model("lca_no_z_angle_3")
 def get_lca_no_z_angle_3_config():
     return {
         "name": "lca_no_z_angle_3",
@@ -173,6 +182,7 @@ def get_lca_no_z_angle_3_config():
     }
 
 
+@register_model("lca_no_bias_4")
 def get_lca_no_bias_4_config():
     return {
         "name": "lca_no_bias_4",
@@ -192,6 +202,7 @@ def get_lca_no_bias_4_config():
     }
 
 
+@register_model("lca_no_bias_angle_4")
 def get_lca_no_bias_angle_4_config():
     return {
         "name": "lca_no_bias_angle_4",

--- a/ssms/config/_modelconfig/levy.py
+++ b/ssms/config/_modelconfig/levy.py
@@ -2,8 +2,10 @@
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
+from ssms.config.registry import register_model
 
 
+@register_model("levy")
 def get_levy_config():
     """Get configuration for levy model."""
     return {
@@ -21,6 +23,7 @@ def get_levy_config():
     }
 
 
+@register_model("levy_angle")
 def get_levy_angle_config():
     """Get configuration for levy model with angle boundary."""
     return {

--- a/ssms/config/_modelconfig/mic2/adj.py
+++ b/ssms/config/_modelconfig/mic2/adj.py
@@ -2,8 +2,10 @@
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
+from ssms.config.registry import register_model
 
 
+@register_model("ddm_mic2_adj")
 def get_ddm_mic2_adj_config():
     """Get configuration for DDM mic2 adj model."""
     return {
@@ -23,7 +25,7 @@ def get_ddm_mic2_adj_config():
         "simulator": cssm.ddm_flexbound_mic2_ornstein,
     }
 
-
+@register_model("ddm_mic2_adj_no_bias")
 def get_ddm_mic2_adj_no_bias_config():
     """Get configuration for DDM mic2 adj no bias model."""
     return {
@@ -43,7 +45,7 @@ def get_ddm_mic2_adj_no_bias_config():
         "simulator": cssm.ddm_flexbound_mic2_ornstein,
     }
 
-
+@register_model("ddm_mic2_adj_conflict_gamma_no_bias")
 def get_ddm_mic2_adj_conflict_gamma_no_bias_config():
     """Get configuration for DDM mic2 adj conflict gamma no bias model."""
     return {
@@ -74,7 +76,7 @@ def get_ddm_mic2_adj_conflict_gamma_no_bias_config():
         "simulator": cssm.ddm_flexbound_mic2_ornstein,
     }
 
-
+@register_model("ddm_mic2_adj_angle_no_bias")
 def get_ddm_mic2_adj_angle_no_bias_config():
     """Get configuration for DDM mic2 adj angle no bias model."""
     return {
@@ -95,7 +97,7 @@ def get_ddm_mic2_adj_angle_no_bias_config():
         "simulator": cssm.ddm_flexbound_mic2_ornstein,
     }
 
-
+@register_model("ddm_mic2_adj_weibull_no_bias")
 def get_ddm_mic2_adj_weibull_no_bias_config():
     """Get configuration for DDM mic2 adj weibull no bias model."""
     return {

--- a/ssms/config/_modelconfig/mic2/leak.py
+++ b/ssms/config/_modelconfig/mic2/leak.py
@@ -2,8 +2,10 @@
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
+from ssms.config.registry import register_model
 
 
+@register_model("ddm_mic2_leak")
 def get_ddm_mic2_leak_config():
     """Get configuration for DDM mic2 leak model."""
     return {
@@ -24,6 +26,7 @@ def get_ddm_mic2_leak_config():
     }
 
 
+@register_model("ddm_mic2_leak_no_bias")
 def get_ddm_mic2_leak_no_bias_config():
     """Get configuration for DDM mic2 leak no bias model."""
     return {
@@ -44,6 +47,7 @@ def get_ddm_mic2_leak_no_bias_config():
     }
 
 
+@register_model("ddm_mic2_leak_conflict_gamma_no_bias")
 def get_ddm_mic2_leak_conflict_gamma_no_bias_config():
     """Get configuration for DDM mic2 leak conflict gamma no bias model."""
     return {
@@ -75,6 +79,7 @@ def get_ddm_mic2_leak_conflict_gamma_no_bias_config():
     }
 
 
+@register_model("ddm_mic2_leak_angle_no_bias")
 def get_ddm_mic2_leak_angle_no_bias_config():
     """Get configuration for DDM mic2 leak angle no bias model."""
     return {
@@ -96,6 +101,7 @@ def get_ddm_mic2_leak_angle_no_bias_config():
     }
 
 
+@register_model("ddm_mic2_leak_weibull_no_bias")
 def get_ddm_mic2_leak_weibull_no_bias_config():
     """Get configuration for DDM mic2 leak weibull no bias model."""
     return {

--- a/ssms/config/_modelconfig/mic2/multinoise.py
+++ b/ssms/config/_modelconfig/mic2/multinoise.py
@@ -2,8 +2,10 @@
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
+from ssms.config.registry import register_model
 
 
+@register_model("ddm_mic2_multinoise_no_bias")
 def get_ddm_mic2_multinoise_no_bias_config():
     """Get configuration for DDM MIC2 multinoise model without bias."""
     return {
@@ -24,6 +26,7 @@ def get_ddm_mic2_multinoise_no_bias_config():
     }
 
 
+@register_model("ddm_mic2_multinoise_conflict_gamma_no_bias")
 def get_ddm_mic2_multinoise_conflict_gamma_no_bias_config():
     """Get configuration for DDM MIC2 multinoise model with conflict gamma boundary and no bias."""
     return {
@@ -55,6 +58,7 @@ def get_ddm_mic2_multinoise_conflict_gamma_no_bias_config():
     }
 
 
+@register_model("ddm_mic2_multinoise_angle_no_bias")
 def get_ddm_mic2_multinoise_angle_no_bias_config():
     """Get configuration for DDM MIC2 multinoise model with angle boundary and no bias."""
     return {
@@ -76,6 +80,7 @@ def get_ddm_mic2_multinoise_angle_no_bias_config():
     }
 
 
+@register_model("ddm_mic2_multinoise_weibull_no_bias")
 def get_ddm_mic2_multinoise_weibull_no_bias_config():
     """Get configuration for DDM MIC2 multinoise model with Weibull boundary and no bias."""
     return {

--- a/ssms/config/_modelconfig/mic2/ornstein.py
+++ b/ssms/config/_modelconfig/mic2/ornstein.py
@@ -2,8 +2,10 @@
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
+from ssms.config.registry import register_model
 
 
+@register_model("ddm_mic2_ornstein")
 def get_ddm_mic2_ornstein_config():
     """Get configuration for DDM mic2 ornstein model."""
     return {
@@ -23,7 +25,7 @@ def get_ddm_mic2_ornstein_config():
         "simulator": cssm.ddm_flexbound_mic2_ornstein,
     }
 
-
+@register_model("ddm_mic2_ornstein_no_bias")
 def get_ddm_mic2_ornstein_no_bias_config():
     """Get configuration for DDM mic2 ornstein no bias model."""
     return {
@@ -43,7 +45,7 @@ def get_ddm_mic2_ornstein_no_bias_config():
         "simulator": cssm.ddm_flexbound_mic2_ornstein,
     }
 
-
+@register_model("ddm_mic2_ornstein_conflict_gamma_no_bias")
 def get_ddm_mic2_ornstein_conflict_gamma_no_bias_config():
     """Get configuration for DDM mic2 ornstein conflict gamma no bias model."""
     return {
@@ -75,7 +77,7 @@ def get_ddm_mic2_ornstein_conflict_gamma_no_bias_config():
         "simulator": cssm.ddm_flexbound_mic2_ornstein,
     }
 
-
+@register_model("ddm_mic2_ornstein_angle_no_bias")
 def get_ddm_mic2_ornstein_angle_no_bias_config():
     """Get configuration for DDM mic2 ornstein angle no bias model."""
     return {
@@ -96,7 +98,7 @@ def get_ddm_mic2_ornstein_angle_no_bias_config():
         "simulator": cssm.ddm_flexbound_mic2_ornstein,
     }
 
-
+@register_model("ddm_mic2_ornstein_weibull_no_bias")
 def get_ddm_mic2_ornstein_weibull_no_bias_config():
     """Get configuration for DDM mic2 ornstein weibull no bias model."""
     return {

--- a/ssms/config/_modelconfig/race.py
+++ b/ssms/config/_modelconfig/race.py
@@ -2,8 +2,10 @@
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
+from ssms.config.registry import register_model
 
 
+@register_model("race_2")
 def get_race_2_config():
     """Get configuration for race model with 2 choices."""
     return {
@@ -24,6 +26,7 @@ def get_race_2_config():
     }
 
 
+@register_model("race_no_bias_2")
 def get_race_no_bias_2_config():
     """Get configuration for race model with 2 choices and no bias."""
     return {
@@ -44,6 +47,7 @@ def get_race_no_bias_2_config():
     }
 
 
+@register_model("race_no_z_2")
 def get_race_no_z_2_config():
     """Get configuration for race model with 2 choices and no z."""
     return {
@@ -64,6 +68,7 @@ def get_race_no_z_2_config():
     }
 
 
+@register_model("race_no_bias_angle_2")
 def get_race_no_bias_angle_2_config():
     """Get configuration for race model with 2 choices and no bias and angle boundary."""
     return {
@@ -84,6 +89,7 @@ def get_race_no_bias_angle_2_config():
     }
 
 
+@register_model("race_no_z_angle_2")
 def get_race_no_z_angle_2_config():
     """Get configuration for race model with 2 choices and no z and angle boundary."""
     return {
@@ -104,6 +110,7 @@ def get_race_no_z_angle_2_config():
     }
 
 
+@register_model("race_3")
 def get_race_3_config():
     """Get configuration for race model with 3 choices."""
     return {
@@ -124,6 +131,7 @@ def get_race_3_config():
     }
 
 
+@register_model("race_no_bias_3")
 def get_race_no_bias_3_config():
     """Get configuration for race model with 3 choices and no bias."""
     return {
@@ -144,6 +152,7 @@ def get_race_no_bias_3_config():
     }
 
 
+@register_model("race_no_z_3")
 def get_race_no_z_3_config():
     """Get configuration for race model with 3 choices and no z."""
     return {
@@ -164,6 +173,7 @@ def get_race_no_z_3_config():
     }
 
 
+@register_model("race_no_bias_angle_3")
 def get_race_no_bias_angle_3_config():
     """Get configuration for race model with 3 choices and no bias and angle boundary."""
     return {
@@ -184,6 +194,7 @@ def get_race_no_bias_angle_3_config():
     }
 
 
+@register_model("race_no_z_angle_3")
 def get_race_no_z_angle_3_config():
     """Get configuration for race model with 3 choices and no z and angle boundary."""
     return {
@@ -204,6 +215,7 @@ def get_race_no_z_angle_3_config():
     }
 
 
+@register_model("race_4")
 def get_race_4_config():
     """Get configuration for race model with 4 choices."""
     return {
@@ -224,6 +236,7 @@ def get_race_4_config():
     }
 
 
+@register_model("race_no_bias_4")
 def get_race_no_bias_4_config():
     """Get configuration for race model with 4 choices and no bias."""
     return {
@@ -244,6 +257,7 @@ def get_race_no_bias_4_config():
     }
 
 
+@register_model("race_no_z_4")
 def get_race_no_z_4_config():
     """Get configuration for race model with 4 choices and no z."""
     return {
@@ -264,6 +278,7 @@ def get_race_no_z_4_config():
     }
 
 
+@register_model("race_no_bias_angle_4")
 def get_race_no_bias_angle_4_config():
     """Get configuration for race model with 4 choices and no bias and angle boundary."""
     return {
@@ -284,6 +299,7 @@ def get_race_no_bias_angle_4_config():
     }
 
 
+@register_model("race_no_z_angle_4")
 def get_race_no_z_angle_4_config():
     """Get configuration for race model with 4 choices and no z and angle boundary."""
     return {

--- a/ssms/config/_modelconfig/shrink.py
+++ b/ssms/config/_modelconfig/shrink.py
@@ -3,8 +3,10 @@
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
 from ssms.basic_simulators import drift_functions as df
+from ssms.config.registry import register_model
 
 
+@register_model("shrink_spot")
 def get_shrink_spot_config():
     """Get configuration for shrink spot model."""
     return {
@@ -36,6 +38,7 @@ def get_shrink_spot_config():
     }
 
 
+@register_model("shrink_spot_extended")
 def get_shrink_spot_extended_config():
     """Get configuration for extended shrink spot model."""
     return {
@@ -67,6 +70,7 @@ def get_shrink_spot_extended_config():
     }
 
 
+@register_model("shrink_spot_simple")
 def get_shrink_spot_simple_config():
     """Get configuration for simple shrink spot model."""
     return {
@@ -97,6 +101,7 @@ def get_shrink_spot_simple_config():
     }
 
 
+@register_model("shrink_spot_simple_extended")
 def get_shrink_spot_simple_extended_config():
     """Get configuration for extended simple shrink spot model."""
     return {

--- a/ssms/config/_modelconfig/tradeoff.py
+++ b/ssms/config/_modelconfig/tradeoff.py
@@ -2,8 +2,10 @@
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
+from ssms.config.registry import register_model
 
 
+@register_model("tradeoff_no_bias")
 def get_tradeoff_no_bias_config():
     """Get configuration for tradeoff model without bias."""
     return {
@@ -23,7 +25,7 @@ def get_tradeoff_no_bias_config():
         "simulator": cssm.ddm_flexbound_tradeoff,
     }
 
-
+@register_model("tradeoff_angle_no_bias")
 def get_tradeoff_angle_no_bias_config():
     """Get configuration for tradeoff model with angle boundary and no bias."""
     return {
@@ -44,7 +46,7 @@ def get_tradeoff_angle_no_bias_config():
         "simulator": cssm.ddm_flexbound_tradeoff,
     }
 
-
+@register_model("tradeoff_weibull_no_bias")
 def get_tradeoff_weibull_no_bias_config():
     """Get configuration for tradeoff model with Weibull boundary and no bias."""
     return {
@@ -64,7 +66,7 @@ def get_tradeoff_weibull_no_bias_config():
         "simulator": cssm.ddm_flexbound_tradeoff,
     }
 
-
+@register_model("tradeoff_conflict_gamma_no_bias")
 def get_tradeoff_conflict_gamma_no_bias_config():
     """Get configuration for tradeoff model with conflict gamma boundary and no bias."""
     return {

--- a/ssms/config/_modelconfig/weibull.py
+++ b/ssms/config/_modelconfig/weibull.py
@@ -2,8 +2,10 @@
 
 import cssm
 from ssms.basic_simulators import boundary_functions as bf
+from ssms.config.registry import register_model
 
 
+@register_model("weibull")
 def get_weibull_config():
     """Get the configuration for the Weibull model."""
     return {

--- a/ssms/config/registry.py
+++ b/ssms/config/registry.py
@@ -1,0 +1,22 @@
+_model_registry = {}
+
+
+def register_model(name: str):
+    def decorator(func):
+        if name in _model_registry:
+            raise ValueError(f"Model '{name}' already registered")
+        _model_registry[name] = func
+        return func
+
+    return decorator
+
+
+def get_model_config(name: str):
+    try:
+        return _model_registry[name]()
+    except KeyError:
+        raise ValueError(f"No model config found for '{name}'")
+
+
+def get_all_model_configs():
+    return dict((name, func()) for name, func in _model_registry.items())


### PR DESCRIPTION
This pull request introduces a consistent registration mechanism for various model configurations in the `ssms` package by adding the `@register_model` decorator to each model's configuration function. This change ensures that all models are properly registered in the system for easier management and usage. Below is a categorized summary of the most important changes:

### General Model Registration
* Added the `@register_model` decorator to the configuration functions for the following models:
  - `angle` in `ssms/config/_modelconfig/angle.py`
  - `ddm` in `ssms/config/_modelconfig/ddm.py`
  - `ddm_par2` and its variants in `ssms/config/_modelconfig/ddm_par2.py` [[1]](diffhunk://#diff-275e018ae6898e541a8f1f4717d34d631b3329b7a1bb727aefd7c0e7c078f427R5-R8) [[2]](diffhunk://#diff-275e018ae6898e541a8f1f4717d34d631b3329b7a1bb727aefd7c0e7c078f427R28) [[3]](diffhunk://#diff-275e018ae6898e541a8f1f4717d34d631b3329b7a1bb727aefd7c0e7c078f427R45) [[4]](diffhunk://#diff-275e018ae6898e541a8f1f4717d34d631b3329b7a1bb727aefd7c0e7c078f427R75) [[5]](diffhunk://#diff-275e018ae6898e541a8f1f4717d34d631b3329b7a1bb727aefd7c0e7c078f427R96)
  - `ddm_st` and its variants in `ssms/config/_modelconfig/ddm_random.py` [[1]](diffhunk://#diff-9eb85a0f7a0413dae1578310ad2c30f13a70e6223c5785d098f7ec7f49c70741R9-R11) [[2]](diffhunk://#diff-9eb85a0f7a0413dae1578310ad2c30f13a70e6223c5785d098f7ec7f49c70741L39-R40) [[3]](diffhunk://#diff-9eb85a0f7a0413dae1578310ad2c30f13a70e6223c5785d098f7ec7f49c70741L73-R74) [[4]](diffhunk://#diff-9eb85a0f7a0413dae1578310ad2c30f13a70e6223c5785d098f7ec7f49c70741L105-R106)
  - `ddm_seq2` and its variants in `ssms/config/_modelconfig/ddm_seq2.py` [[1]](diffhunk://#diff-9575fdc42a41f1ae6082e6200eb783604a93c2d13b88e8cf6b2452d0e3e8f81aR5-R8) [[2]](diffhunk://#diff-9575fdc42a41f1ae6082e6200eb783604a93c2d13b88e8cf6b2452d0e3e8f81aR29) [[3]](diffhunk://#diff-9575fdc42a41f1ae6082e6200eb783604a93c2d13b88e8cf6b2452d0e3e8f81aR47) [[4]](diffhunk://#diff-9575fdc42a41f1ae6082e6200eb783604a93c2d13b88e8cf6b2452d0e3e8f81aR78) [[5]](diffhunk://#diff-9575fdc42a41f1ae6082e6200eb783604a93c2d13b88e8cf6b2452d0e3e8f81aR100)

### Specialized Models
* Registered additional models in the following files:
  - `dev_rlwm_lba.py` for `dev_rlwm_lba_pw_v1` and its variants [[1]](diffhunk://#diff-78ee84b537be877845e5678522d0f6223ddbac4da8d620846f5e5dc956c5e08fR5-R8) [[2]](diffhunk://#diff-78ee84b537be877845e5678522d0f6223ddbac4da8d620846f5e5dc956c5e08fR38) [[3]](diffhunk://#diff-78ee84b537be877845e5678522d0f6223ddbac4da8d620846f5e5dc956c5e08fR69)
  - `full_ddm.py` for `full_ddm` and `full_ddm_rv` [[1]](diffhunk://#diff-6e0f1a3590b71c32a66a8734f19c4050baceb89f2de6f9af5c9fbb01cbbba447R8-R11) [[2]](diffhunk://#diff-6e0f1a3590b71c32a66a8734f19c4050baceb89f2de6f9af5c9fbb01cbbba447R32)
  - `gamma_drift.py` for `gamma_drift` and `gamma_drift_angle` [[1]](diffhunk://#diff-097803c6fe000be795ebba14917de60bcf51a6723f5adcc8bb733165e92455dbR5-R8) [[2]](diffhunk://#diff-097803c6fe000be795ebba14917de60bcf51a6723f5adcc8bb733165e92455dbL28-R30)

### LBA and LCA Models
* Added registration for LBA models in `lba.py`, including `lba2`, `lba3`, and their variants [[1]](diffhunk://#diff-eb6ccc7f57164cfaa36719ceac4f39af5d3eade1258f92410684b93b33b4dc44R5-R8) [[2]](diffhunk://#diff-eb6ccc7f57164cfaa36719ceac4f39af5d3eade1258f92410684b93b33b4dc44R26) [[3]](diffhunk://#diff-eb6ccc7f57164cfaa36719ceac4f39af5d3eade1258f92410684b93b33b4dc44R44) [[4]](diffhunk://#diff-eb6ccc7f57164cfaa36719ceac4f39af5d3eade1258f92410684b93b33b4dc44R63) [[5]](diffhunk://#diff-eb6ccc7f57164cfaa36719ceac4f39af5d3eade1258f92410684b93b33b4dc44L76-R81).
* Registered LCA models in `lca.py`, such as `lca_3`, `lca_4`, and their bias/no-bias variants [[1]](diffhunk://#diff-38cfd9216b0e60004b7efd556e12f6f4d9bcacc379b47ba799161f56ae490d5aR5-R8) [[2]](diffhunk://#diff-38cfd9216b0e60004b7efd556e12f6f4d9bcacc379b47ba799161f56ae490d5aR28) [[3]](diffhunk://#diff-38cfd9216b0e60004b7efd556e12f6f4d9bcacc379b47ba799161f56ae490d5aR49) [[4]](diffhunk://#diff-38cfd9216b0e60004b7efd556e12f6f4d9bcacc379b47ba799161f56ae490d5aR83) [[5]](diffhunk://#diff-38cfd9216b0e60004b7efd556e12f6f4d9bcacc379b47ba799161f56ae490d5aR104) [[6]](diffhunk://#diff-38cfd9216b0e60004b7efd556e12f6f4d9bcacc379b47ba799161f56ae490d5aR125) [[7]](diffhunk://#diff-38cfd9216b0e60004b7efd556e12f6f4d9bcacc379b47ba799161f56ae490d5aR145) [[8]](diffhunk://#diff-38cfd9216b0e60004b7efd556e12f6f4d9bcacc379b47ba799161f56ae490d5aR165) [[9]](diffhunk://#diff-38cfd9216b0e60004b7efd556e12f6f4d9bcacc379b47ba799161f56ae490d5aR185) [[10]](diffhunk://#diff-38cfd9216b0e60004b7efd556e12f6f4d9bcacc379b47ba799161f56ae490d5aR205).

### Other Models
* Registered models in the following files:
  - `levy.py` for `levy` and `levy_angle` [[1]](diffhunk://#diff-9b8c20fea881e50d6e3460f3a970c6b6ee516f0c6654521a3cca1a5b4856638fR5-R8) [[2]](diffhunk://#diff-9b8c20fea881e50d6e3460f3a970c6b6ee516f0c6654521a3cca1a5b4856638fR26)
  - `mic2/adj.py` for `ddm_mic2_adj` and its no-bias variant [[1]](diffhunk://#diff-b4057519334308e2bd19ad37955cbaec502cbe42561ac2fd8ca9dbfb6e315b69R5-R8) [[2]](diffhunk://#diff-b4057519334308e2bd19ad37955cbaec502cbe42561ac2fd8ca9dbfb6e315b69L26-R28)