### PR TITLE
195 make generate config path optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,3 +154,6 @@ omit = [
 
 [project.scripts]
 generate = "ssms.cli.generate:app"
+
+[tool.setuptools.package-data]
+"ssms.cli" = ["config_network_training_lan.yaml"]

--- a/ssms/cli/generate.py
+++ b/ssms/cli/generate.py
@@ -6,6 +6,7 @@ import warnings
 import yaml
 from collections import namedtuple
 from copy import deepcopy
+from importlib.resources import files, as_file
 from pathlib import Path
 from pprint import pformat
 
@@ -161,7 +162,7 @@ log_level_option = typer.Option(
 
 @app.command()
 def main(
-    config_path: Path = typer.Option(..., help="Path to the YAML configuration file."),
+    config_path: Path = typer.Option(None, help="Path to the YAML configuration file."),
     output: Path = typer.Option(..., help="Path to the output directory."),
     log_level: str = log_level_option,
 ):
@@ -173,10 +174,12 @@ def main(
     )
     logger = logging.getLogger(__name__)
 
-    # Casting config_path to str for now
-    # TODO: Fix this in the future
-    config_path = str(config_path)
-    output = str(output)
+    if config_path is None:
+        logger.warning("No config path provided, using default configuration.")
+        with as_file(
+            files("ssms.cli") / "config_data_generation.yaml"
+        ) as default_config:
+            config_path = default_config
 
     config_dict = collect_data_generator_config(
         yaml_config_path=config_path, base_path=output

--- a/tests/test_generate_cli.py
+++ b/tests/test_generate_cli.py
@@ -85,28 +85,24 @@ def test_collect_data_generator_config(tmp_path, yaml_config):
     assert data_config["delta_t"] == 0.1
 
 
+@pytest.mark.parametrize("config_path", [None, "config.yaml"])
 @patch("ssms.dataset_generators.lan_mlp.data_generator")
-def test_main(mock_data_generator, tmp_path, yaml_config):
-    config_path = tmp_path / "config.yaml"
-    with open(config_path, "w") as f:
-        yaml.dump(yaml_config, f)
+def test_main(mock_data_generator, tmp_path, yaml_config, config_path):
+    if config_path is not None:
+        config_path = tmp_path / config_path
+        with open(config_path, "w") as f:
+            yaml.dump(yaml_config, f)
 
-    # Prepare mock data generator
     mock_generator_instance = MagicMock()
     mock_data_generator.return_value = mock_generator_instance
 
-    # Call main with test configuration
     with patch("typer.echo"), patch("typer.Exit"):
-        # Patch the yaml_file parameter to be None
-        with patch("ssms.cli.generate.main", wraps=main) as mock_main:
-            mock_main(
-                config_path=config_path,
-                output=tmp_path,
-                log_level="info",
-            )
-
-    # Verify data generator was called
-    mock_data_generator.assert_called_once()
-    mock_generator_instance.generate_data_training_uniform.assert_called_once_with(
-        save=True, cpn_only=False
-    )
+        main(
+            config_path=config_path,
+            output=tmp_path,
+            log_level="info",
+        )
+        mock_data_generator.assert_called_once()
+        mock_generator_instance.generate_data_training_uniform.assert_called_once_with(
+            save=True, cpn_only=False
+        )


### PR DESCRIPTION
This pull request updates the configuration handling in the `ssms.cli.generate` CLI tool to improve usability and test coverage. The main change allows the CLI to use a default configuration file when no config path is provided, and updates related packaging and tests to support this behavior.

**Configuration handling improvements:**

* The `main` function's `config_path` parameter is now optional; if not provided, the CLI will use a default configuration file bundled with the package (`config_data_generation.yaml`). [[1]](diffhunk://#diff-a7ee3514d1a41a664d53afc8c7311ae2a66f6fe3fc2c0a53b30fc5678f19e917L164-R165) [[2]](diffhunk://#diff-a7ee3514d1a41a664d53afc8c7311ae2a66f6fe3fc2c0a53b30fc5678f19e917L176-R182)
* The default configuration file is included in the package data via the `pyproject.toml` configuration.

**Testing enhancements:**

* The `test_main` test is now parameterized to check both cases: when a config path is provided and when it is not, ensuring the CLI works correctly with and without an explicit config file.

**Dependency and import updates:**

* The CLI imports `files` and `as_file` from `importlib.resources` to load the default configuration file at runtime.