### PR TITLE
Fix generate missing dep in v0.10.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ssm-simulators"
-version = "0.10.2"
+version = "0.10.3"
 description = "SSMS is a package collecting simulators and training data generators for cognitive science, neuroscience, and approximate bayesian computation"
 authors = [
     { name = "Alexander Fengler", email = "alexander_fengler@brown.edu" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.13" # for compatibility with lanfactory
 dependencies = [
     "scipy >= 1.6.3",
     "pandas >= 1.0.0",
@@ -20,9 +20,9 @@ dependencies = [
     "psutil >= 5.0.0",
     "pathos >= 0.3.0",
     "numpy>=2.0",
-    "dill>=0.3.9",
     "typer>=0.15.3",
     "pyyaml>=6.0.2",
+    "tqdm>=4.67.1",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -154,3 +154,6 @@ omit = [
 
 [project.scripts]
 generate = "ssms.cli.generate:app"
+
+[tool.setuptools.package-data]
+"ssms.cli" = ["config_network_training_lan.yaml"]

--- a/ssms/cli/generate.py
+++ b/ssms/cli/generate.py
@@ -5,6 +5,7 @@ import pickle
 import warnings
 from collections import namedtuple
 from copy import deepcopy
+from importlib.resources import files, as_file
 from pathlib import Path
 from pprint import pformat
 
@@ -164,7 +165,7 @@ epilog = "Example: `generate --config-path myconfig.yaml --output ./output --n-f
 
 @app.command(epilog=epilog)
 def main(
-    config_path: Path = typer.Option(..., help="Path to the YAML configuration file."),
+    config_path: Path = typer.Option(None, help="Path to the YAML configuration file."),
     output: Path = typer.Option(..., help="Path to the output directory."),
     n_files: int = typer.Option(
         1,
@@ -184,10 +185,12 @@ def main(
     )
     logger = logging.getLogger(__name__)
 
-    # Casting config_path to str for now
-    # TODO: Fix this in the future
-    config_path = str(config_path)
-    output = str(output)
+    if config_path is None:
+        logger.warning("No config path provided, using default configuration.")
+        with as_file(
+            files("ssms.cli") / "config_data_generation.yaml"
+        ) as default_config:
+            config_path = default_config
 
     config_dict = collect_data_generator_config(
         yaml_config_path=config_path, base_path=output
@@ -207,7 +210,9 @@ def main(
 
     is_cpn = config_dict["data_config"].get("cpn_only", False)
 
-    for i in tqdm.tqdm(range(n_files), desc="Generating simulated data files", unit="file"):
+    for i in tqdm.tqdm(
+        range(n_files), desc="Generating simulated data files", unit="file"
+    ):
         my_dataset_generator.generate_data_training_uniform(save=True, cpn_only=is_cpn)
 
     logger.info("Data generation finished")


### PR DESCRIPTION
## For immediate release

v0.10.2 doesn't include the `tqdm` dependency which is used in the `generate` CLI. Because Lanfactory's deps include this dep, this bug wasn't detected in that package or in the lan_pipe_minimal repo. These changes are already contained in #185. 