### PR TITLE
Validate param names in drift and boundary configs

### DIFF
--- a/ssms/config/_modelconfig/__init__.py
+++ b/ssms/config/_modelconfig/__init__.py
@@ -128,7 +128,8 @@ from .shrink import (
     get_shrink_spot_simple_config,
     get_shrink_spot_simple_extended_config,
 )
-from .validation import validate_param_names
+from .base import drift_config, boundary_config
+from .validation import get_invalid_configs
 
 
 def get_model_config():
@@ -293,16 +294,13 @@ __all__ = [
 
 # Validate
 
-try:
-    _ALL_MODEL_CONFIGS = get_model_config()
-    valid_model = {}
-    for _model_name, _cfg in _ALL_MODEL_CONFIGS.items():
-        valid_model[_model_name] = validate_param_names(_cfg["params"])
-except Exception as _e:
-    raise RuntimeError(
-        (
-            f"Model config validation failed during import.\n"
-            f"Model name: {_model_name}.\n"
-            f"Error: {_e}"
-        )
-    ) from _e
+_ALL_CONFIGS = {
+    "model_configs": get_model_config(),
+    "drift_configs": drift_config,
+    "boundary_configs": boundary_config,
+}
+invalid_configs = {
+    key: get_invalid_configs(configs) for key, configs in _ALL_CONFIGS.items()
+}
+if any(invalid_configs.values()):
+    raise ValueError(f"Invalid parameter names detected: {invalid_configs}")

--- a/ssms/config/_modelconfig/base.py
+++ b/ssms/config/_modelconfig/base.py
@@ -63,8 +63,8 @@ drift_config = {
     "conflict_stimflex_drift": {
         "fun": df.conflict_stimflex_drift,
         "params": [
-            "v_t",
-            "v_d",
+            "vt",
+            "vd",
             "tcoh",
             "dcoh",
             "tonset",
@@ -73,13 +73,13 @@ drift_config = {
     },
     "conflict_stimflexrel1_drift": {
         "fun": df.conflict_stimflexrel1_drift,
-        "params": ["v_t", "v_d", "tcoh", "dcoh", "tonset", "donset"],
+        "params": ["vt", "vd", "tcoh", "dcoh", "tonset", "donset"],
     },
     "conflict_stimflexrel1_dual_drift": {
         "fun": df.conflict_stimflexrel1_dual_drift,
         "params": [
-            "v_t",
-            "v_d",
+            "vt",
+            "vd",
             "tcoh",
             "dcoh",
             "tonset",

--- a/ssms/config/_modelconfig/validation.py
+++ b/ssms/config/_modelconfig/validation.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import re
 from typing import Any, List
 
-NAME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9]{0,30}$")
+NAME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9\.]{0,30}$")
 
 
 def is_valid_param_name(name: Any) -> bool:
@@ -16,7 +16,6 @@ def is_valid_param_name(name: Any) -> bool:
 
     Rules:
     - must be a str
-    - must not be in RESERVED_NAMES
     - must match NAME_RE
     """
     if not isinstance(name, str):
@@ -24,7 +23,7 @@ def is_valid_param_name(name: Any) -> bool:
     return bool(NAME_RE.match(name))
 
 
-def validate_param_names(params: list) -> None:
+def get_invalid_param_names(params: list) -> List[str]:
     """Validate only the parameter names in ``params``.
 
     This checks that `params` is a list, that there are no duplicates,
@@ -44,12 +43,13 @@ def validate_param_names(params: list) -> None:
         raise ValueError(f"Duplicate parameter names: {sorted(set(dupes))}")
     # name checks
     invalid = [p for p in params if not is_valid_param_name(p)]
-    if invalid:
-        raise ValueError(
-            "Invalid parameter name(s): {}. Names must be str and match '{}'.".format(
-                invalid, NAME_RE.pattern
-            )
-        )
+    return invalid
 
 
-__all__ = ["is_valid_param_name", "validate_param_names"]
+def get_invalid_configs(configs: dict[str, dict]) -> list[str]:
+    return [
+        name for name, cfg in configs.items() if get_invalid_param_names(cfg["params"])
+    ]
+
+
+__all__ = ["is_valid_param_name", "get_invalid_param_names", "get_invalid_configs"]


### PR DESCRIPTION
Some of the param names in the new conflict drift function configs still contained underscores because these drift configs were not included in the param-name validation. This led to drift parameters supplied in theta being overwritten with default values during simulation.

This commit also tweaks the allowable param names to include dots in non-initial positions #226 