### PR TITLE
Update project version to 0.12.0b1 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Alexander Fengler", email = "alexander_fengler@brown.edu" },
 ]
 readme = "README.md"
-license = {text = "MIT"}
+license = { text = "MIT" }
 requires-python = ">3.10,<3.14" # for compatibility with lanfactory
 dependencies = [
     "scipy >= 1.6.3",
@@ -66,7 +66,7 @@ dev = [
     "pytest",
     "mypy",
     "black",
-    "ruff",
+    "ruff>=0.15.1",
     "pre-commit",
     "pytest-cov>=6.0.0",
     "pytest-xdist>=3.6.1",

--- a/ssms/config/_modelconfig/ddm_random.py
+++ b/ssms/config/_modelconfig/ddm_random.py
@@ -39,13 +39,15 @@ def get_ddm_st_config():
             "sampling": [],
             "simulation": [
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {
-                            "z_dist": cfg["simulator_fixed_params"]["z_dist"],
-                            "v_dist": cfg["simulator_fixed_params"]["v_dist"],
-                        }
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update(
+                            {
+                                "z_dist": cfg["simulator_fixed_params"]["z_dist"],
+                                "v_dist": cfg["simulator_fixed_params"]["v_dist"],
+                            }
+                        )
+                        or theta
+                    ),
                     name="set_fixed_params",
                 ),
                 ApplyMapping("st", "t_dist", "t_dist"),
@@ -89,14 +91,16 @@ def get_ddm_truncnormt_config():
             "sampling": [],
             "simulation": [
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {
-                            "z_dist": cfg["simulator_fixed_params"]["z_dist"],
-                            "v_dist": cfg["simulator_fixed_params"]["v_dist"],
-                            "t": np.array([0], dtype=np.float32),
-                        }
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update(
+                            {
+                                "z_dist": cfg["simulator_fixed_params"]["z_dist"],
+                                "v_dist": cfg["simulator_fixed_params"]["v_dist"],
+                                "t": np.array([0], dtype=np.float32),
+                            }
+                        )
+                        or theta
+                    ),
                     name="set_fixed_params_and_zero_t",
                 ),
                 ApplyMapping("mt", "t_dist", "t_dist", additional_sources=["st"]),
@@ -138,16 +142,18 @@ def get_ddm_rayleight_config():
             "sampling": [],
             "simulation": [
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {
-                            "z_dist": cfg["simulator_fixed_params"]["z_dist"],
-                            "v_dist": cfg["simulator_fixed_params"]["v_dist"],
-                            "t": (
-                                np.ones(n) * cfg["simulator_fixed_params"]["t"]
-                            ).astype(np.float32),
-                        }
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update(
+                            {
+                                "z_dist": cfg["simulator_fixed_params"]["z_dist"],
+                                "v_dist": cfg["simulator_fixed_params"]["v_dist"],
+                                "t": (
+                                    np.ones(n) * cfg["simulator_fixed_params"]["t"]
+                                ).astype(np.float32),
+                            }
+                        )
+                        or theta
+                    ),
                     name="set_fixed_params_and_t",
                 ),
                 ApplyMapping("st", "t_dist", "t_dist"),
@@ -185,13 +191,15 @@ def get_ddm_sdv_config():
             "sampling": [],
             "simulation": [
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {
-                            "z_dist": cfg["simulator_fixed_params"]["z_dist"],
-                            "t_dist": cfg["simulator_fixed_params"]["t_dist"],
-                        }
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update(
+                            {
+                                "z_dist": cfg["simulator_fixed_params"]["z_dist"],
+                                "t_dist": cfg["simulator_fixed_params"]["t_dist"],
+                            }
+                        )
+                        or theta
+                    ),
                     name="set_fixed_dists",
                 ),
                 ApplyMapping("sv", "v_dist", "v_dist"),

--- a/ssms/config/_modelconfig/dev_rlwm_lba.py
+++ b/ssms/config/_modelconfig/dev_rlwm_lba.py
@@ -52,10 +52,9 @@ def get_dev_rlwm_lba_pw_v1_config():
                 ),
                 ExpandDimension(["a", "z", "tWM"]),
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {"t": np.zeros(n).astype(np.float32)}
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update({"t": np.zeros(n).astype(np.float32)}) or theta
+                    ),
                     name="set_zero_t",
                 ),
             ],
@@ -105,10 +104,9 @@ def get_dev_rlwm_lba_race_v1_config():
                 ),
                 ExpandDimension(["a", "z"]),
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {"t": np.zeros(n).astype(np.float32)}
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update({"t": np.zeros(n).astype(np.float32)}) or theta
+                    ),
                     name="set_zero_t",
                 ),
             ],
@@ -155,10 +153,9 @@ def get_dev_rlwm_lba_race_v2_config():
                 ),
                 ExpandDimension(["a", "z"]),
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {"t": np.zeros(n).astype(np.float32)}
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update({"t": np.zeros(n).astype(np.float32)}) or theta
+                    ),
                     name="set_zero_t",
                 ),
             ],

--- a/ssms/config/_modelconfig/lca.py
+++ b/ssms/config/_modelconfig/lca.py
@@ -192,10 +192,9 @@ def get_lca_no_bias_3_config():
             "sampling": [],
             "simulation": [
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {"z": np.column_stack([theta["z"]] * 3)}
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update({"z": np.column_stack([theta["z"]] * 3)}) or theta
+                    ),
                     name="duplicate_z_3",
                 ),
                 ColumnStackParameters(["v0", "v1", "v2"], "v", delete_sources=False),
@@ -225,10 +224,9 @@ def get_lca_no_bias_angle_3_config():
             "sampling": [],
             "simulation": [
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {"z": np.column_stack([theta["z"]] * 3)}
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update({"z": np.column_stack([theta["z"]] * 3)}) or theta
+                    ),
                     name="duplicate_z_3",
                 ),
                 ColumnStackParameters(["v0", "v1", "v2"], "v", delete_sources=False),
@@ -285,10 +283,9 @@ def get_lca_no_bias_4_config():
             "sampling": [],
             "simulation": [
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {"z": np.column_stack([theta["z"]] * 4)}
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update({"z": np.column_stack([theta["z"]] * 4)}) or theta
+                    ),
                     name="duplicate_z_4",
                 ),
                 ColumnStackParameters(
@@ -320,10 +317,9 @@ def get_lca_no_bias_angle_4_config():
             "sampling": [],
             "simulation": [
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {"z": np.column_stack([theta["z"]] * 4)}
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update({"z": np.column_stack([theta["z"]] * 4)}) or theta
+                    ),
                     name="duplicate_z_4",
                 ),
                 ColumnStackParameters(

--- a/ssms/config/_modelconfig/race.py
+++ b/ssms/config/_modelconfig/race.py
@@ -61,10 +61,10 @@ def get_race_no_bias_2_config():
             "sampling": [],
             "simulation": [
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {"z": np.column_stack([theta["z"], theta["z"]])}
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update({"z": np.column_stack([theta["z"], theta["z"]])})
+                        or theta
+                    ),
                     name="duplicate_z_2",
                 ),
                 ColumnStackParameters(["v0", "v1"], "v", delete_sources=False),
@@ -123,10 +123,10 @@ def get_race_no_bias_angle_2_config():
             "sampling": [],
             "simulation": [
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {"z": np.column_stack([theta["z"], theta["z"]])}
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update({"z": np.column_stack([theta["z"], theta["z"]])})
+                        or theta
+                    ),
                     name="duplicate_z_2",
                 ),
                 ColumnStackParameters(["v0", "v1"], "v", delete_sources=False),
@@ -213,10 +213,12 @@ def get_race_no_bias_3_config():
             "sampling": [],
             "simulation": [
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {"z": np.column_stack([theta["z"], theta["z"], theta["z"]])}
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update(
+                            {"z": np.column_stack([theta["z"], theta["z"], theta["z"]])}
+                        )
+                        or theta
+                    ),
                     name="duplicate_z_3",
                 ),
                 ColumnStackParameters(["v0", "v1", "v2"], "v", delete_sources=False),
@@ -275,10 +277,12 @@ def get_race_no_bias_angle_3_config():
             "sampling": [],
             "simulation": [
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {"z": np.column_stack([theta["z"], theta["z"], theta["z"]])}
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update(
+                            {"z": np.column_stack([theta["z"], theta["z"], theta["z"]])}
+                        )
+                        or theta
+                    ),
                     name="duplicate_z_3",
                 ),
                 ColumnStackParameters(["v0", "v1", "v2"], "v", delete_sources=False),
@@ -369,10 +373,9 @@ def get_race_no_bias_4_config():
             "sampling": [],
             "simulation": [
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {"z": np.column_stack([theta["z"]] * 4)}
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update({"z": np.column_stack([theta["z"]] * 4)}) or theta
+                    ),
                     name="duplicate_z_4",
                 ),
                 ColumnStackParameters(
@@ -435,10 +438,9 @@ def get_race_no_bias_angle_4_config():
             "sampling": [],
             "simulation": [
                 LambdaAdaptation(
-                    lambda theta, cfg, n: theta.update(
-                        {"z": np.column_stack([theta["z"]] * 4)}
-                    )
-                    or theta,
+                    lambda theta, cfg, n: (
+                        theta.update({"z": np.column_stack([theta["z"]] * 4)}) or theta
+                    ),
                     name="duplicate_z_4",
                 ),
                 ColumnStackParameters(


### PR DESCRIPTION
This pull request updates the version of the `ssm-simulators` package to a new beta release. No other changes are included.

* Bumped the package version in `pyproject.toml` from `0.11.3` to `0.12.0b1` to indicate a new beta release.
* Bumped version of ruff formatter and reformat files per the latest version.