### PR TITLE
Fix windows error where random seeds could be too large for C long

### DIFF
--- a/notebooks/int_bug_test.ipynb
+++ b/notebooks/int_bug_test.ipynb
@@ -1,0 +1,106 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "43c1105f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ssms.basic_simulators.simulator import simulator as ssm_sim\n",
+    "\n",
+    "\n",
+    "for i in range(100):\n",
+    "    ddm_sim = ssm_sim(model=\"ddm\",\n",
+    "                    theta=dict(v=0.5, a=1.0, z=0.5, t=0.7), \n",
+    "                    n_samples=10000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "2c4ffbb4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(100):\n",
+    "    ddm_sim = ssm_sim(model=\"levy\",\n",
+    "                      theta = [0.0, 1.0, 0.5, 1.5, 0.1],\n",
+    "                      n_samples=10000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d9fcd9ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(100):\n",
+    "    ddm_sim = ssm_sim(model=\"ddm_legacy\",\n",
+    "                      theta=dict(v=0.5, a=1.0, z=0.5, t=0.7), \n",
+    "                      n_samples=10000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6ecaeede",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ssms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "00744448",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0.12.3'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ssms.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2569591e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/test_ziggurat.ipynb
+++ b/notebooks/test_ziggurat.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4f67029d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "import random\n",
+    "import numpy as np\n",
+    "\n",
+    "# =============================\n",
+    "# Constants\n",
+    "# =============================\n",
+    "\n",
+    "N = 128\n",
+    "R = 3.442619855899\n",
+    "INV_R = 1.0 / R\n",
+    "\n",
+    "# =============================\n",
+    "# Table generation (Doornik)\n",
+    "# =============================\n",
+    "\n",
+    "def generate_tables():\n",
+    "    x = [0.0] * (N + 1)\n",
+    "    f = [0.0] * (N + 1)\n",
+    "\n",
+    "    x[0] = R\n",
+    "    f[0] = math.exp(-0.5 * R * R)\n",
+    "\n",
+    "    for i in range(1, N):\n",
+    "        x[i] = math.sqrt(-2.0 * math.log(\n",
+    "            f[i-1] + (f[i-1] - f[i-2]) / x[i-1] if i > 1 else f[0] * INV_R\n",
+    "        ))\n",
+    "        f[i] = math.exp(-0.5 * x[i] * x[i])\n",
+    "\n",
+    "    x[N] = 0.0\n",
+    "    f[N] = 1.0\n",
+    "    return x, f\n",
+    "\n",
+    "\n",
+    "X, F = generate_tables()\n",
+    "\n",
+    "# =============================\n",
+    "# Tail sampler\n",
+    "# =============================\n",
+    "\n",
+    "def sample_tail():\n",
+    "    while True:\n",
+    "        x = -math.log(random.random()) * INV_R\n",
+    "        y = -math.log(random.random())\n",
+    "        if 2.0 * y >= x * x:\n",
+    "            return R + x\n",
+    "\n",
+    "# =============================\n",
+    "# Ziggurat sampler\n",
+    "# =============================\n",
+    "\n",
+    "def ziggurat_gaussian():\n",
+    "    while True:\n",
+    "        i = random.getrandbits(7)  # strip\n",
+    "        u = random.random()\n",
+    "        x = u * X[i]\n",
+    "\n",
+    "        if x < X[i + 1]:\n",
+    "            return x if random.getrandbits(1) else -x\n",
+    "\n",
+    "        if i == 0:\n",
+    "            x = sample_tail()\n",
+    "            return x if random.getrandbits(1) else -x\n",
+    "\n",
+    "        y = F[i] + random.random() * (F[i + 1] - F[i])\n",
+    "        if y < math.exp(-0.5 * x * x):\n",
+    "            return x if random.getrandbits(1) else -x\n",
+    "\n",
+    "def ziggurat_rng(samples: int = 500_000, seed: int = 42):\n",
+    "    # rng = random.Random(seed)\n",
+    "    zigg_samples = [ziggurat_gaussian() for _ in range(samples)]\n",
+    "    # mean = np.mean(zigg_samples)\n",
+    "    # var = np.var(zigg_samples)\n",
+    "    return zigg_samples\n",
+    "    print(f\"Mean: {mean:.6f}, Var: {var:.6f}\")\n",
+    "\n",
+    "\n",
+    "\n",
+    "# if __name__ == \"__main__\":\n",
+    "#     for i in range(10):\n",
+    "#         seed = np.random.randint(0, 1000000)\n",
+    "#         test_ziggurat(samples=500_000, seed=seed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "322fdeba",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([49181., 50077., 50081., 50307., 50320., 50526., 50025., 49871.,\n",
+       "        50243., 49369.]),\n",
+       " array([-4.26362595e+00, -3.41089805e+00, -2.55817016e+00, -1.70544226e+00,\n",
+       "        -8.52714363e-01,  1.35332284e-05,  8.52741430e-01,  1.70546933e+00,\n",
+       "         2.55819722e+00,  3.41092512e+00,  4.26365302e+00]),\n",
+       " <BarContainer object of 10 artists>)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjkAAAGdCAYAAADwjmIIAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjcsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvTLEjVAAAAAlwSFlzAAAPYQAAD2EBqD+naQAAIXNJREFUeJzt3Q2s1fV9P/APD/IgCAxUqAGEzU6gKkye19aUlUE7bObEDTpjEdEFg0SklYfOQGtMMLoNaAHpYlbIJgHZoh0wcAQGZhOLhZIBG6TdcNBRHmwFlMmDwD/fb3Lu/15Ey1XovffL65X8cs7v/D7nd373Hu49b75Pt9G5c+fOBQBAYRrX9QUAAFwOQg4AUCQhBwAokpADABRJyAEAiiTkAABFEnIAgCIJOQBAkZrGFezs2bOxf//+uOaaa6JRo0Z1fTkAwEVI6xi/8847ccMNN0Tjxh/eXnNFh5wUcLp06VLXlwEAfAz79u2Lzp07f+jxKzrkpBacyjepTZs2dX05AMBFOHbsWG6kqHyOf5grOuRUuqhSwBFyAKBh+VVDTQw8BgCKJOQAAEUScgCAIgk5AECRhBwAoEhCDgBQJCEHACiSkAMAFEnIAQCKJOQAAEUScgCAIgk5AECRhBwAoEhCDgBQpKa1Kf7Wt74V3/72t2s8dvPNN8euXbvy/RMnTsTXv/71WLp0aZw8eTKGDx8eCxYsiI4dO1bV7927Nx5++OH4l3/5l2jdunWMGTMmZs2aFU2b/v9L2bBhQ0yePDl27twZXbp0iSeeeCLuv//+Gq87f/78ePbZZ+PAgQPRu3fv+O53vxsDBgz4uN8HoEDdpq2KhubNp0fU9SXAlduS85nPfCZ+/vOfV23/+q//WnXsscceixUrVsTy5ctj48aNsX///rj77rurjp85cyZGjBgRp06ditdeey0WL14cixYtihkzZlTV7NmzJ9cMGTIktm3bFpMmTYoHH3wwXnnllaqaZcuW5RA0c+bM2Lp1aw45KVAdOnTok303AIBiNDp37ty52rTkvPzyyzl8nO/o0aNx3XXXxZIlS+Kee+7Jj6UWnp49e8amTZti0KBBsXr16rjzzjtz+Km07ixcuDCmTp0ahw8fjmbNmuX7q1atih07dlSde/To0XHkyJFYs2ZN3h84cGD0798/5s2bl/fPnj2bW3wmTpwY06ZNu+gv/tixY9G2bdt87W3atLno58GV1rrAr4+WnF+Phvhz6N9G7T+/a9VdlfzkJz+JG264IVq0aBGDBw/OXU1du3aNLVu2xOnTp2Po0KFVtT169MjHKiEn3d566601uq9SC0zqvkpdU7/zO7+Ta6qfo1KTWnSS1AqUXmv69OlVxxs3bpyfk577UVIXWtqqf5No2D/0AHBJQk5qQUndS2kcTuqqSuNzPv/5z+dWlzQ2JrXEtGvXrsZzUqBJx5J0Wz3gVI5Xjn1UTQok7733Xrz99tu52+tCNZWxQR8mBbLzxxQB1CcN8T8bWhgoIuR8+ctfrrp/22235dBz4403xosvvhgtW7aM+i61/qSxPBUpOKVuLgCurGDGleETTSFPrTa//du/HT/96U+jU6dOuSspjZ2p7uDBg/lYkm7T/vnHK8c+qib1uaUgde2110aTJk0uWFM5x4dp3rx5Pk/1DQAo0ycKOe+++27813/9V3zqU5+Kvn37xlVXXRXr1q2rOr579+48ZTyN3UnS7fbt22vMglq7dm0OG7169aqqqX6OSk3lHKlLLL1W9Zo08DjtV2oAAGrVXfWNb3wjvvKVr+QuqjRDKk3hTq0qX/3qV/Mo53HjxuXuoPbt2+fgkmY7peCRBh0nw4YNy2Hmvvvui2eeeSaPv0lr4EyYMCG3siTjx4/Ps6amTJkSDzzwQKxfvz53h6UZVxXpNdL6Ov369ctr48yZMyeOHz8eY8eO9Y4CUKSG2C34Zh2v+1SrkPOzn/0sB5pf/OIXebr45z73uXj99dfz/WT27Nl5ptPIkSNrLAZYkQLRypUr82yqFH5atWqVw8qTTz5ZVdO9e/ccaNKaO3Pnzo3OnTvH888/n89VMWrUqDzlPK2vk4JSnz598vTy8wcjAwBXrlqtk1Oay7lOTkNM3ADQEFpyLvbz29+uAgCKJOQAAEUScgCAIgk5AECRhBwAoEhCDgBQJCEHACiSkAMAFEnIAQCKJOQAAEUScgCAIgk5AECRhBwAoEhCDgBQJCEHACiSkAMAFEnIAQCKJOQAAEUScgCAIgk5AECRhBwAoEhCDgBQJCEHACiSkAMAFEnIAQCKJOQAAEUScgCAIgk5AECRhBwAoEhCDgBQJCEHACiSkAMAFEnIAQCKJOQAAEUScgCAIgk5AECRhBwAoEhCDgBQJCEHACiSkAMAFEnIAQCKJOQAAEUScgCAIgk5AECRhBwAoEhCDgBQJCEHACiSkAMAFEnIAQCKJOQAAEUScgCAIgk5AECRhBwAoEhCDgBQJCEHACiSkAMAFEnIAQCKJOQAAEX6RCHn6aefjkaNGsWkSZOqHjtx4kRMmDAhOnToEK1bt46RI0fGwYMHazxv7969MWLEiLj66qvj+uuvj8cffzzef//9GjUbNmyI22+/PZo3bx433XRTLFq06AOvP3/+/OjWrVu0aNEiBg4cGJs3b/4kXw4AUJCPHXLeeOON+N73vhe33XZbjccfe+yxWLFiRSxfvjw2btwY+/fvj7vvvrvq+JkzZ3LAOXXqVLz22muxePHiHGBmzJhRVbNnz55cM2TIkNi2bVsOUQ8++GC88sorVTXLli2LyZMnx8yZM2Pr1q3Ru3fvGD58eBw6dOjjfkkAQEEanTt37lxtn/Tuu+/mVpYFCxbEU089FX369Ik5c+bE0aNH47rrroslS5bEPffck2t37doVPXv2jE2bNsWgQYNi9erVceedd+bw07Fjx1yzcOHCmDp1ahw+fDiaNWuW769atSp27NhR9ZqjR4+OI0eOxJo1a/J+arnp379/zJs3L++fPXs2unTpEhMnToxp06Zd1Ndx7NixaNu2bb7uNm3axKXUbdqqS3o+AGho3nx6xGU578V+fn+slpzUHZVaWoYOHVrj8S1btsTp06drPN6jR4/o2rVrDjlJur311lurAk6SWmDSBe/cubOq5vxzp5rKOVIrUHqt6jWNGzfO+5UaAODK1rS2T1i6dGnuHkrdVec7cOBAbolp165djcdToEnHKjXVA07leOXYR9WkIPTee+/F22+/nbu9LlSTWo4+zMmTJ/NWkc4HAJSpVi05+/bti0cffTReeOGFPNi3oZk1a1Zu3qpsqXsLAChTrUJO6iJKA3vTeJymTZvmLQ0u/s53vpPvp5aU1JWUxs5Ul2ZXderUKd9Pt+fPtqrs/6qa1O/WsmXLuPbaa6NJkyYXrKmc40KmT5+e++8qWwptAECZahVyvvjFL8b27dvzjKfK1q9fv7j33nur7l911VWxbt26qufs3r07TxkfPHhw3k+36RzVZ0GtXbs2B5hevXpV1VQ/R6Wmco7UJda3b98aNWngcdqv1FxImo6eXqf6BgCUqVZjcq655pq45ZZbajzWqlWrvCZO5fFx48blqd3t27fPISLNdkrBI82sSoYNG5bDzH333RfPPPNMHn/zxBNP5MHMKYQk48ePz7OmpkyZEg888ECsX78+XnzxxTzjqiK9xpgxY3KwGjBgQJ7ddfz48Rg7duyl+L4AAFfawONfZfbs2XmmU1oEMA3yTbOi0lTzitTNtHLlynj44Ydz+EkhKYWVJ598sqqme/fuOdCkNXfmzp0bnTt3jueffz6fq2LUqFF5ynlaXycFpTSNPU0vP38wMgBwZfpY6+SUwjo5AHD5NMh1cgAA6jshBwAokpADABRJyAEAiiTkAABFEnIAgCIJOQBAkYQcAKBIQg4AUCQhBwAokpADABRJyAEAiiTkAABFEnIAgCIJOQBAkYQcAKBIQg4AUCQhBwAokpADABRJyAEAiiTkAABFEnIAgCIJOQBAkYQcAKBIQg4AUCQhBwAokpADABRJyAEAiiTkAABFEnIAgCIJOQBAkYQcAKBIQg4AUCQhBwAokpADABRJyAEAiiTkAABFEnIAgCIJOQBAkYQcAKBIQg4AUCQhBwAokpADABRJyAEAiiTkAABFEnIAgCIJOQBAkYQcAKBIQg4AUCQhBwAokpADABRJyAEAiiTkAABFEnIAgCIJOQBAkYQcAKBIQg4AUCQhBwAokpADABSpViHnueeei9tuuy3atGmTt8GDB8fq1aurjp84cSImTJgQHTp0iNatW8fIkSPj4MGDNc6xd+/eGDFiRFx99dVx/fXXx+OPPx7vv/9+jZoNGzbE7bffHs2bN4+bbropFi1a9IFrmT9/fnTr1i1atGgRAwcOjM2bN9f+qwcAilWrkNO5c+d4+umnY8uWLfGjH/0ofu/3fi/+8A//MHbu3JmPP/bYY7FixYpYvnx5bNy4Mfbv3x9333131fPPnDmTA86pU6fitddei8WLF+cAM2PGjKqaPXv25JohQ4bEtm3bYtKkSfHggw/GK6+8UlWzbNmymDx5csycOTO2bt0avXv3juHDh8ehQ4cuzXcFAGjwGp07d+7cJzlB+/bt49lnn4177rknrrvuuliyZEm+n+zatSt69uwZmzZtikGDBuVWnzvvvDOHn44dO+aahQsXxtSpU+Pw4cPRrFmzfH/VqlWxY8eOqtcYPXp0HDlyJNasWZP3U8tN//79Y968eXn/7Nmz0aVLl5g4cWJMmzbtoq/92LFj0bZt2zh69GhumbqUuk1bdUnPBwANzZtPj7gs573Yz++PPSYntcosXbo0jh8/nrutUuvO6dOnY+jQoVU1PXr0iK5du+aQk6TbW2+9tSrgJKkFJl1spTUo1VQ/R6Wmco7UCpReq3pN48aN836l5sOcPHkyv1b1DQAoU61Dzvbt2/N4mzReZvz48fHSSy9Fr1694sCBA7klpl27djXqU6BJx5J0Wz3gVI5Xjn1UTQok7733Xrz11ls5YF2opnKODzNr1qyc/Cpbav0BAMpU65Bz880357EyP/zhD+Phhx+OMWPGxH/8x39EQzB9+vTctFXZ9u3bV9eXBABcJk1r+4TUWpNmPCV9+/aNN954I+bOnRujRo3KXUlp7Ez11pw0u6pTp075fro9fxZUZfZV9ZrzZ2Sl/dTn1rJly2jSpEneLlRTOceHSa1PaQMAyveJ18lJg37TWJcUeK666qpYt25d1bHdu3fnKeNpzE6SblN3V/VZUGvXrs0BJnV5VWqqn6NSUzlHClnptarXpGtI+5UaAICmte3u+fKXv5wHE7/zzjt5JlVa0yZN705jXMaNG5endqcZVym4pNlOKXikmVXJsGHDcpi577774plnnsljaJ544om8tk6lhSWN80mzpqZMmRIPPPBArF+/Pl588cU846oivUbqJuvXr18MGDAg5syZkwdAjx071jsKANQ+5KQWmK997Wvx85//PIeatDBgCji///u/n4/Pnj07z3RKiwCm1p00K2rBggVVz0/dTCtXrsxjeVL4adWqVQ4rTz75ZFVN9+7dc6BJa+6kbrC0Ns/zzz+fz1WRusbSlPO0vk4KSn369MnTy88fjAwAXLk+8To5DZl1cgDg8mmw6+QAANRnQg4AUCQhBwAokpADABRJyAEAiiTkAABFEnIAgCIJOQBAkYQcAKBIQg4AUCQhBwAokpADABRJyAEAiiTkAABFEnIAgCIJOQBAkYQcAKBIQg4AUCQhBwAokpADABRJyAEAiiTkAABFEnIAgCIJOQBAkYQcAKBIQg4AUCQhBwAokpADABRJyAEAiiTkAABFEnIAgCIJOQBAkYQcAKBIQg4AUCQhBwAokpADABRJyAEAiiTkAABFEnIAgCIJOQBAkYQcAKBIQg4AUCQhBwAokpADABRJyAEAiiTkAABFEnIAgCIJOQBAkYQcAKBIQg4AUCQhBwAokpADABRJyAEAiiTkAABFEnIAgCIJOQBAkYQcAKBIQg4AUCQhBwAoUq1CzqxZs6J///5xzTXXxPXXXx933XVX7N69u0bNiRMnYsKECdGhQ4do3bp1jBw5Mg4ePFijZu/evTFixIi4+uqr83kef/zxeP/992vUbNiwIW6//fZo3rx53HTTTbFo0aIPXM/8+fOjW7du0aJFixg4cGBs3ry5dl89AFCsWoWcjRs35gDz+uuvx9q1a+P06dMxbNiwOH78eFXNY489FitWrIjly5fn+v3798fdd99ddfzMmTM54Jw6dSpee+21WLx4cQ4wM2bMqKrZs2dPrhkyZEhs27YtJk2aFA8++GC88sorVTXLli2LyZMnx8yZM2Pr1q3Ru3fvGD58eBw6dOiTf1cAgAav0blz58593CcfPnw4t8SkMHPHHXfE0aNH47rrroslS5bEPffck2t27doVPXv2jE2bNsWgQYNi9erVceedd+bw07Fjx1yzcOHCmDp1aj5fs2bN8v1Vq1bFjh07ql5r9OjRceTIkVizZk3eTy03qVVp3rx5ef/s2bPRpUuXmDhxYkybNu2irv/YsWPRtm3bfN1t2rSJS6nbtFWX9HwA0NC8+fSIy3Lei/38/kRjctLJk/bt2+fbLVu25NadoUOHVtX06NEjunbtmkNOkm5vvfXWqoCTpBaYdME7d+6sqql+jkpN5RypFSi9VvWaxo0b5/1KzYWcPHkyv071DQAo08cOOanlJHUjffazn41bbrklP3bgwIHcEtOuXbsatSnQpGOVmuoBp3K8cuyjalIoee+99+Ktt97K3V4Xqqmc48PGFKXkV9lSyw8AUKaPHXLS2JzUnbR06dJoKKZPn55bnyrbvn376vqSAIDLpOnHedIjjzwSK1eujFdffTU6d+5c9XinTp1yV1IaO1O9NSfNrkrHKjXnz4KqzL6qXnP+jKy0n/rdWrZsGU2aNMnbhWoq57iQNFMrbQBA+WrVkpPGKKeA89JLL8X69euje/fuNY737ds3rrrqqli3bl3VY2mKeZoyPnjw4Lyfbrdv315jFlSaqZUCTK9evapqqp+jUlM5R+oSS69VvSZ1n6X9Sg0AcGVrWtsuqjRz6gc/+EFeK6cy/iWNb0ktLOl23LhxeWp3Goycgkua7ZSCR5pZlaQp5ynM3HffffHMM8/kczzxxBP53JVWlvHjx+dZU1OmTIkHHnggB6oXX3wxz7iqSK8xZsyY6NevXwwYMCDmzJmTp7KPHTv20n6HAIDyQ85zzz2Xb7/whS/UePz73/9+3H///fn+7Nmz80yntAhgms2UZkUtWLCgqjZ1M6WurocffjiHn1atWuWw8uSTT1bVpBaiFGjSmjtz587NXWLPP/98PlfFqFGj8pTztL5OCkp9+vTJ08vPH4wMAFyZPtE6OQ2ddXIA4PJp0OvkAADUV0IOAFAkIQcAKJKQAwAUScgBAIok5AAARRJyAIAiCTkAQJGEHACgSEIOAFAkIQcAKJKQAwAUScgBAIok5AAARRJyAIAiCTkAQJGEHACgSEIOAFAkIQcAKJKQAwAUScgBAIok5AAARRJyAIAiCTkAQJGEHACgSEIOAFAkIQcAKJKQAwAUScgBAIok5AAARRJyAIAiCTkAQJGEHACgSEIOAFAkIQcAKJKQAwAUScgBAIok5AAARRJyAIAiCTkAQJGEHACgSEIOAFAkIQcAKJKQAwAUScgBAIok5AAARRJyAIAiCTkAQJGEHACgSEIOAFAkIQcAKJKQAwAUScgBAIok5AAARRJyAIAiCTkAQJGEHACgSEIOAFCkWoecV199Nb7yla/EDTfcEI0aNYqXX365xvFz587FjBkz4lOf+lS0bNkyhg4dGj/5yU9q1Pzyl7+Me++9N9q0aRPt2rWLcePGxbvvvluj5t///d/j85//fLRo0SK6dOkSzzzzzAeuZfny5dGjR49cc+utt8Y//dM/1fbLAQAKVeuQc/z48ejdu3fMnz//gsdTGPnOd74TCxcujB/+8IfRqlWrGD58eJw4caKqJgWcnTt3xtq1a2PlypU5OP3Zn/1Z1fFjx47FsGHD4sYbb4wtW7bEs88+G9/61rfir//6r6tqXnvttfjqV7+aA9KPf/zjuOuuu/K2Y8eO2n8XAIDiNDqXml4+7pMbNYqXXnoph4sknSq18Hz961+Pb3zjG/mxo0ePRseOHWPRokUxevTo+M///M/o1atXvPHGG9GvX79cs2bNmviDP/iD+NnPfpaf/9xzz8Wf//mfx4EDB6JZs2a5Ztq0abnVaNeuXXl/1KhROXClkFQxaNCg6NOnTw5YFyOFqbZt2+ZrTK1Kl1K3aasu6fkAoKF58+kRl+W8F/v5fUnH5OzZsycHk9RFVZEuYuDAgbFp06a8n25TF1Ul4CSpvnHjxrnlp1Jzxx13VAWcJLUG7d69O95+++2qmuqvU6mpvA4AcGVreilPlgJOklpuqkv7lWPp9vrrr695EU2bRvv27WvUdO/e/QPnqBz7jd/4jXz7Ua9zISdPnsxb9SQIAJTpippdNWvWrNyyVNnSgGYAoEyXNOR06tQp3x48eLDG42m/cizdHjp0qMbx999/P8+4ql5zoXNUf40Pq6kcv5Dp06fn/rvKtm/fvk/w1QIAV0zISV1MKWSsW7euRpdQGmszePDgvJ9ujxw5kmdNVaxfvz7Onj2bx+5UatKMq9OnT1fVpJlYN998c+6qqtRUf51KTeV1LqR58+Z5gFL1DQAoU61DTlrPZtu2bXmrDDZO9/fu3ZtnW02aNCmeeuqp+Md//MfYvn17fO1rX8szpiozsHr27Blf+tKX4qGHHorNmzfHv/3bv8UjjzySZ16luuRP//RP86DjND08TTVftmxZzJ07NyZPnlx1HY8++mielfWXf/mXecZVmmL+ox/9KJ8LAKDWA49TkBgyZEjVfiV4jBkzJk8TnzJlSp7anda9SS02n/vc53IYSQv2Vbzwwgs5jHzxi1/Ms6pGjhyZ19apSONl/vmf/zkmTJgQffv2jWuvvTYvMFh9LZ3f/d3fjSVLlsQTTzwR3/zmN+PTn/50nmJ+yy23eFcBgE+2Tk5DZ50cALh8ilonBwCgvhByAIAiCTkAQJGEHACgSEIOAFAkIQcAKJKQAwAUScgBAIok5AAARRJyAIAiCTkAQJGEHACgSEIOAFAkIQcAKJKQAwAUScgBAIok5AAARRJyAIAiCTkAQJGEHACgSEIOAFAkIQcAKJKQAwAUScgBAIok5AAARRJyAIAiCTkAQJGEHACgSEIOAFAkIQcAKJKQAwAUScgBAIok5AAARRJyAIAiCTkAQJGEHACgSEIOAFAkIQcAKJKQAwAUScgBAIok5AAARRJyAIAiCTkAQJGEHACgSEIOAFAkIQcAKJKQAwAUScgBAIok5AAARRJyAIAiCTkAQJGEHACgSEIOAFAkIQcAKJKQAwAUScgBAIok5AAARRJyAIAiCTkAQJEafMiZP39+dOvWLVq0aBEDBw6MzZs31/UlAQD1QIMOOcuWLYvJkyfHzJkzY+vWrdG7d+8YPnx4HDp0qK4vDQCoYw065PzVX/1VPPTQQzF27Njo1atXLFy4MK6++ur4m7/5m7q+NACgjjWNBurUqVOxZcuWmD59etVjjRs3jqFDh8amTZsu+JyTJ0/mreLo0aP59tixY5f8+s6e/L9Lfk4AaEiOXYbP1+rnPXfuXJkh56233oozZ85Ex44dazye9nft2nXB58yaNSu+/e1vf+DxLl26XLbrBIArVds5l/f877zzTrRt27a8kPNxpFafNIan4uzZs/HLX/4yOnToEI0aNYq6lpJpClz79u2LNm3a1PXl8CG8Tw2D96n+8x41DMfq4WdTasFJAeeGG274yLoGG3KuvfbaaNKkSRw8eLDG42m/U6dOF3xO8+bN81Zdu3btor5J/4jqyz8kPpz3qWHwPtV/3qOGoU09+2z6qBacBj/wuFmzZtG3b99Yt25djZaZtD948OA6vTYAoO412JacJHU9jRkzJvr16xcDBgyIOXPmxPHjx/NsKwDgytagQ86oUaPi8OHDMWPGjDhw4ED06dMn1qxZ84HByA1F6kpLa/6c36VG/eJ9ahi8T/Wf96hhaN6AP5sanftV868AABqgBjsmBwDgowg5AECRhBwAoEhCDgBQJCGnnkt/ayvNGksrMm/btq2uL4dq3nzzzRg3blx07949WrZsGb/1W7+VZyCkv6tG3Zo/f35069YtWrRoEQMHDozNmzd7S+qR9Cd2+vfvH9dcc01cf/31cdddd8Xu3bvr+rL4CE8//XT+HJo0aVI0JEJOPTdlypRfuWw1dSP9jbS0AOX3vve92LlzZ8yePTsWLlwY3/zmN70ldWjZsmV5Da0UOLdu3Rq9e/eO4cOHx6FDh7wv9cTGjRtjwoQJ8frrr8fatWvj9OnTMWzYsLzOGfXPG2+8kX/P3XbbbdHQmEJej61evTr/sv6Hf/iH+MxnPhM//vGPc6sO9dezzz4bzz33XPz3f/93XV/KFSu13KRWgnnz5uX9FETT392ZOHFiTJs2ra4vjwtI652lFp0Ufu644w7fo3rk3Xffjdtvvz0WLFgQTz31VP4MSgvvNhRacuqp9De4Hnroofjbv/3buPrqq+v6crhIR48ejfbt2/t+1ZHUVbhly5YYOnRo1WONGzfO+5s2bfK+1OOfm8TPTv0zYcKEGDFiRI2fqYakQa94XKq0PuP9998f48ePz3+yIo39oP776U9/Gt/97nfjL/7iL+r6Uq5Yb731Vpw5c+YDq56n/dS9SP2TWtrSOI/Pfvazccstt9T15VDN0qVLc5dv6q5qqLTk/BqlpvI0cOujtvSLOH1Qpj8hP3369F/n5VHL96m6//3f/40vfelL8cd//Me5BQ64+JaCHTt25A9U6o99+/bFo48+Gi+88EIewN9QGZPza+53/sUvfvGRNb/5m78Zf/InfxIrVqzIH6YV6X+nTZo0iXvvvTcWL178a7jaK9fFvk/NmjXL9/fv3x9f+MIXYtCgQbFo0aLcPULddVel7t2///u/zzN2KtIf8j1y5Ej84Ac/8NbUI4888kh+T1599dU8S5H64+WXX44/+qM/yp871T+H0udS+h2XZv5WP1ZfCTn10N69e+PYsWNV++lDNM0OSb+406DKzp071+n1UbMFZ8iQIdG3b9/4u7/7uwbxQ1+69DMyYMCA3CJa6Q7p2rVr/kA18Lj+dMmngeAvvfRSbNiwIT796U/X9SVxntSb8D//8z81Hhs7dmz06NEjpk6d2mC6Fo3JqYfSL+TqWrdunW/TOiwCTv0KOKkF58Ybb8zjcFILUEWnTp3q9NquZGlGYmq5SePZUthJM0HS1OT0C5r600W1ZMmS3IqT1so5cOBAfrxt27Z5zSnq3jXXXPOBINOqVavo0KFDgwk4iZADH1Na3yMNNk7b+eEz/U+VujFq1KgcOGfMmJE/PNOU1zVr1nxgMDJ1Jy2zkKT/JFT3/e9/P0+6gEtFdxUAUCQjJAGAIgk5AECRhBwAoEhCDgBQJCEHACiSkAMAFEnIAQCKJOQAAEUScgCAIgk5AECRhBwAoEhCDgAQJfp/AfTstzjebfwAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "plt.hist(ziggurat_rng())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ssm-simulators"
-version = "0.12.3"
+version = "0.12.4"
 description = "SSMS is a package collecting simulators and training data generators for cognitive science, neuroscience, and approximate bayesian computation"
 authors = [
     { name = "Alexander Fengler", email = "alexander_fengler@brown.edu" },

--- a/ssms/basic_simulators/simulator.py
+++ b/ssms/basic_simulators/simulator.py
@@ -6,6 +6,7 @@ with preprocessing the output of the simulator function.
 """
 
 from copy import deepcopy
+import numbers
 from threading import Lock
 
 import numpy as np
@@ -37,11 +38,43 @@ _rng_lock = Lock()
 
 
 def _get_unique_seed() -> int:
-    """
-    Generate a unique seed for the random number generator.
+    """Generate a unique integer seed for the C-level RNG.
+
+    Seeds must fit in a signed 32-bit C ``long``.  On Windows (LLP64),
+    ``long`` is 32-bit (max ``2**31 - 1``); on macOS/Linux it is often 64-bit.
+    Using ``[0, 2**31)`` is safe on all platforms and matches what
+    ``cssm._utils.set_seed`` can accept without overflow.
     """
     with _rng_lock:
-        return int(_global_rng.integers(0, 2**32 - 1))
+        # high is exclusive -> largest value is 2**31 - 1
+        return int(_global_rng.integers(0, 2**31))
+
+
+# Range accepted by ``cssm._utils.set_seed`` when casting to C ``long`` (32-bit on Windows).
+_RNG_SEED_C_LONG_MIN = -(2**31)
+_RNG_SEED_C_LONG_MAX = 2**31 - 1
+
+
+def _validate_random_state_for_c_rng(random_state: object) -> None:
+    """Raise ``ValueError`` if *random_state* is an integer outside the C ``long`` range.
+
+    The Cython layer casts seeds to ``long``.  On Windows that is 32-bit signed; larger
+    values raise ``OverflowError`` inside Cython.  We validate here with a clear
+    Python error.  Non-integer seeds (e.g. ``numpy.random.Generator``) are skipped;
+    those paths do not use this cast in the same way.
+    """
+    if random_state is None:
+        return
+    if not isinstance(random_state, numbers.Integral):
+        return
+    rs = int(random_state)
+    if rs < _RNG_SEED_C_LONG_MIN or rs > _RNG_SEED_C_LONG_MAX:
+        raise ValueError(
+            f"random_state={rs} is outside [{_RNG_SEED_C_LONG_MIN}, {_RNG_SEED_C_LONG_MAX}], "
+            "the range the C-level simulator can use on all platforms (Windows ``long`` "
+            "is 32-bit). Use a smaller integer seed, e.g. "
+            "int(np.random.default_rng().integers(0, 2**31))."
+        )
 
 
 def _make_valid_dict(dict_in: dict) -> dict:
@@ -627,8 +660,10 @@ def simulator(
         smooth_unif: bool <default=True>
             Whether to add uniform random noise to RTs to smooth the distributions.
         random_state: int | None <default=None>
-            Integer passed to random_seed function in the simulator.
-            Can be used for reproducibility.
+            Integer passed to the C-level RNG seeding.  Must lie in
+            ``[-2**31, 2**31 - 1]`` so it fits in a 32-bit signed C ``long`` (required
+            on Windows).  ``None`` draws a seed from that range automatically.
+            Non-integer RNG objects may be supported on specific code paths.
         return_option: str <default='full'>
             Determines what the function returns. Can be either
             'full' or 'minimal'. If 'full' the function returns
@@ -673,6 +708,7 @@ def simulator(
 
     if random_state is None:
         random_state = _get_unique_seed()
+    _validate_random_state_for_c_rng(random_state)
 
     theta = _preprocess_theta_generic(theta)
     n_trials, theta = _preprocess_theta_deadline(

--- a/ssms/basic_simulators/simulator_class.py
+++ b/ssms/basic_simulators/simulator_class.py
@@ -18,6 +18,7 @@ from ssms.basic_simulators.simulator import (
     _get_unique_seed,
     _preprocess_theta_deadline,
     _preprocess_theta_generic,
+    _validate_random_state_for_c_rng,
     make_boundary_dict,
     make_drift_dict,
     make_noise_vec,
@@ -540,7 +541,9 @@ class Simulator:
         smooth_unif : bool, default=True
             Whether to add uniform smoothing to RTs
         random_state : int or None
-            Random seed for reproducibility
+            Integer seed for the C-level RNG. Must lie in ``[-2**31, 2**31 - 1]`` (fits
+            a 32-bit signed C ``long``, required on Windows). ``None`` picks a seed in
+            ``[0, 2**31 - 1]`` automatically.
         return_option : str, default="full"
             Output format: "full" or "minimal"
         n_threads : int, default=1
@@ -572,6 +575,7 @@ class Simulator:
 
         if random_state is None:
             random_state = _get_unique_seed()
+        _validate_random_state_for_c_rng(random_state)
 
         # Preprocess theta
         theta = _preprocess_theta_generic(theta)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -269,3 +269,44 @@ def test_deprecated_get_lan_config_warns():
     with pytest.warns(DeprecationWarning, match="get_lan_config.*deprecated"):
         result = get_lan_config()
     assert result == get_lan_kde_config()
+
+
+def test_get_unique_seed_fits_signed_32bit_c_long():
+    """Auto-generated seeds must not overflow Windows C long (see set_seed in _utils.pyx)."""
+    from ssms.basic_simulators.simulator import _get_unique_seed
+
+    for _ in range(500):
+        s = _get_unique_seed()
+        assert 0 <= s <= 2**31 - 1
+
+
+def test_random_state_too_large_raises_value_error():
+    """User-supplied seeds above 32-bit signed C long must fail fast with a clear error."""
+    with pytest.raises(ValueError, match="random_state"):
+        simulator(
+            model="ddm",
+            theta={"v": 0.0, "a": 1.0, "z": 0.5, "t": 0.1},
+            n_samples=1,
+            random_state=2**31,
+        )
+
+
+def test_random_state_too_negative_raises_value_error():
+    with pytest.raises(ValueError, match="random_state"):
+        simulator(
+            model="ddm",
+            theta={"v": 0.0, "a": 1.0, "z": 0.5, "t": 0.1},
+            n_samples=1,
+            random_state=-(2**31) - 1,
+        )
+
+
+def test_random_state_boundary_max_ok():
+    """Largest valid integer seed should not raise from validation."""
+    out = simulator(
+        model="ddm",
+        theta={"v": 0.0, "a": 1.0, "z": 0.5, "t": 0.1},
+        n_samples=2,
+        random_state=2**31 - 1,
+    )
+    assert "rts" in out

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -301,6 +301,26 @@ def test_random_state_too_negative_raises_value_error():
         )
 
 
+def test_random_state_none_ok():
+    """random_state=None (the default) should not raise."""
+    out = simulator(
+        model="ddm",
+        theta={"v": 0.0, "a": 1.0, "z": 0.5, "t": 0.1},
+        n_samples=2,
+        random_state=None,
+    )
+    assert "rts" in out
+
+
+def test_random_state_non_integer_skips_validation():
+    """Non-integer random_state should skip the C-long range check without raising."""
+    from ssms.basic_simulators.simulator import _validate_random_state_for_c_rng
+
+    # A numpy Generator is not an integer, so validation should be a no-op
+    rng = np.random.default_rng(42)
+    _validate_random_state_for_c_rng(rng)  # should not raise
+
+
 def test_random_state_boundary_max_ok():
     """Largest valid integer seed should not raise from validation."""
     out = simulator(

--- a/uv.lock
+++ b/uv.lock
@@ -4349,9 +4349,10 @@ wheels = [
 
 [[package]]
 name = "ssm-simulators"
-version = "0.12.2"
+version = "0.12.3"
 source = { editable = "." }
 dependencies = [
+    { name = "cloudpickle" },
     { name = "matplotlib" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -4456,6 +4457,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'" },
+    { name = "cloudpickle" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.29.5" },
     { name = "jax", marker = "extra == 'jax'", specifier = ">=0.4.20" },
     { name = "jax", marker = "extra == 'parallel'", specifier = ">=0.4.20" },

--- a/uv.lock
+++ b/uv.lock
@@ -4349,7 +4349,7 @@ wheels = [
 
 [[package]]
 name = "ssm-simulators"
-version = "0.12.3"
+version = "0.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cloudpickle" },


### PR DESCRIPTION
This pull request focuses on improving the robustness and clarity of random seed handling for the C-level random number generator (RNG) used in the simulator. The main changes ensure that integer seeds passed to the simulator are always within the valid range for a 32-bit signed C `long`, preventing platform-dependent errors, especially on Windows. Additionally, the documentation has been updated for clarity, and new tests and notebooks have been added for validation and demonstration purposes.

**Random seed validation and handling improvements:**

- Added a new function `_validate_random_state_for_c_rng` in `simulator.py` to check that integer seeds provided to the simulator are within the valid 32-bit signed C `long` range ([-2**31, 2**31 - 1]). This prevents overflow errors in the Cython layer, particularly on Windows, and provides a clear Python error if the value is out of range.
- Updated the `_get_unique_seed` function to generate seeds within the safe range for all platforms, matching the requirements of the C-level RNG.
- Integrated the new seed validation function into both the `simulator` function and the `simulate` method of `Simulator` class, ensuring all entry points enforce the seed range. [[1]](diffhunk://#diff-a35a9021df53d6d8c3d94b023754cbd17092727c6a3b44c04391b4260ae04ff7R711) [[2]](diffhunk://#diff-d0a9a8f9ba00a8e6c4bd31a1414ab2b6265dbf525061f5a8c4f014388706ce42R578)
- Updated imports in `simulator_class.py` to include the new validation function.

**Documentation updates:**

- Clarified the docstrings for the `random_state` parameter in both `simulator` and `simulate` to specify the valid integer range and the reason for the restriction (compatibility with C `long`). [[1]](diffhunk://#diff-a35a9021df53d6d8c3d94b023754cbd17092727c6a3b44c04391b4260ae04ff7L630-R666) [[2]](diffhunk://#diff-d0a9a8f9ba00a8e6c4bd31a1414ab2b6265dbf525061f5a8c4f014388706ce42L543-R546)

**Testing and demonstration:**

- Added a new notebook `notebooks/int_bug_test.ipynb` to test simulator behavior with various models and seeds, and to check the package version.
- Added a new notebook `notebooks/test_ziggurat.ipynb` that implements and visualizes the Ziggurat algorithm for Gaussian random number generation, likely for further RNG testing or demonstration.

**Other changes:**

- Bumped the package version to `0.12.4` in `pyproject.toml` to reflect these improvements and fixes.
- Added missing import of `numbers` to `simulator.py` for type checking in the new validation function.

These changes make the simulator more robust across platforms, prevent subtle bugs related to random seed overflow, and improve clarity for users and developers.