### PR TITLE
Make assembled RLSSM JAX participant function differentiable

### DIFF
--- a/ssms/rl/assembled.py
+++ b/ssms/rl/assembled.py
@@ -40,18 +40,23 @@ class AssembledFunctionOutput(StrEnum):
     DICT = "dict"
 
 
-def _is_jax_tracer(value: Any) -> bool:
-    """Return True when ``value`` is a JAX tracer (a symbolic trace input).
+def _jax_tracer_errors() -> tuple[type[BaseException], ...]:
+    """Exceptions JAX raises when a tracer is forced to a concrete NumPy array.
 
     Used to skip eager, concrete-only validation when an assembled JAX function
     is being traced for gradients/jit (e.g. during HSSM inference), where the
-    inputs are symbolic and cannot be converted to NumPy.
+    inputs are symbolic and cannot be converted to NumPy. Relies on the public,
+    stable ``jax.errors`` module rather than the internal ``jax.core.Tracer``
+    type, which JAX does not guarantee as a public API.
     """
     if not _jax_available():
-        return False
-    import jax
+        return ()
+    from jax import errors as jax_errors
 
-    return isinstance(value, jax.core.Tracer)
+    return (
+        jax_errors.TracerArrayConversionError,
+        jax_errors.ConcretizationTypeError,
+    )
 
 
 def resolve_model(model: str | ModelConfig) -> ModelConfig:
@@ -325,13 +330,15 @@ class AssembledModel:
 
         Response labels can only be read from a concrete array. During a JAX
         trace (gradient/jit for inference) ``subject_trials`` is a symbolic
-        tracer, so this eager check is skipped; the panel is validated at the
-        data boundary (``ModelConfig.validate_data`` and the concrete Python /
-        eager paths) instead.
+        tracer that cannot be converted to NumPy, so this eager check is
+        skipped; the panel is validated at the data boundary
+        (``ModelConfig.validate_data`` and the concrete Python / eager paths)
+        instead.
         """
-        if _is_jax_tracer(subject_trials):
+        try:
+            trials = np.asarray(subject_trials)
+        except _jax_tracer_errors():
             return
-        trials = np.asarray(subject_trials)
         if trials.ndim == 1:
             trials = trials.reshape(1, -1)
         responses = trials[:, field_to_idx[response_field]]

--- a/ssms/rl/assembled.py
+++ b/ssms/rl/assembled.py
@@ -40,6 +40,20 @@ class AssembledFunctionOutput(StrEnum):
     DICT = "dict"
 
 
+def _is_jax_tracer(value: Any) -> bool:
+    """Return True when ``value`` is a JAX tracer (a symbolic trace input).
+
+    Used to skip eager, concrete-only validation when an assembled JAX function
+    is being traced for gradients/jit (e.g. during HSSM inference), where the
+    inputs are symbolic and cannot be converted to NumPy.
+    """
+    if not _jax_available():
+        return False
+    import jax
+
+    return isinstance(value, jax.core.Tracer)
+
+
 def resolve_model(model: str | ModelConfig) -> ModelConfig:
     """Resolve a preset name or validate an existing RLSSM model config."""
     if isinstance(model, str):
@@ -307,7 +321,16 @@ class AssembledModel:
         field_to_idx: dict[str, int],
         response_field: str,
     ) -> None:
-        """Raise when trial responses are absent from ``response_to_choice``."""
+        """Raise when trial responses are absent from ``response_to_choice``.
+
+        Response labels can only be read from a concrete array. During a JAX
+        trace (gradient/jit for inference) ``subject_trials`` is a symbolic
+        tracer, so this eager check is skipped; the panel is validated at the
+        data boundary (``ModelConfig.validate_data`` and the concrete Python /
+        eager paths) instead.
+        """
+        if _is_jax_tracer(subject_trials):
+            return
         trials = np.asarray(subject_trials)
         if trials.ndim == 1:
             trials = trials.reshape(1, -1)

--- a/tests/rl/test_assembled_model.py
+++ b/tests/rl/test_assembled_model.py
@@ -212,6 +212,13 @@ class TestAssembledModel:
 
         assert np.all(np.isfinite(np.asarray(grad)))
 
+    def test_is_jax_tracer_false_when_jax_unavailable(self, monkeypatch):
+        """``_is_jax_tracer`` returns False when JAX is not installed."""
+        from ssms.rl import assembled
+
+        monkeypatch.setattr(assembled, "_jax_available", lambda: False)
+        assert assembled._is_jax_tracer(object()) is False
+
     def test_jax_subject_wise_function_rejects_unmapped_response_labels(self):
         pytest.importorskip("jax.numpy")
 

--- a/tests/rl/test_assembled_model.py
+++ b/tests/rl/test_assembled_model.py
@@ -212,12 +212,12 @@ class TestAssembledModel:
 
         assert np.all(np.isfinite(np.asarray(grad)))
 
-    def test_is_jax_tracer_false_when_jax_unavailable(self, monkeypatch):
-        """``_is_jax_tracer`` returns False when JAX is not installed."""
+    def test_jax_tracer_errors_empty_when_jax_unavailable(self, monkeypatch):
+        """``_jax_tracer_errors`` is an empty tuple when JAX is not installed."""
         from ssms.rl import assembled
 
         monkeypatch.setattr(assembled, "_jax_available", lambda: False)
-        assert assembled._is_jax_tracer(object()) is False
+        assert assembled._jax_tracer_errors() == ()
 
     def test_jax_subject_wise_function_rejects_unmapped_response_labels(self):
         pytest.importorskip("jax.numpy")

--- a/tests/rl/test_assembled_model.py
+++ b/tests/rl/test_assembled_model.py
@@ -178,6 +178,40 @@ class TestAssembledModel:
 
         np.testing.assert_allclose(np.asarray(values), [0.0, -0.5, -1.0, -1.25])
 
+    def test_jax_subject_wise_function_is_differentiable(self):
+        """grad through the assembled JAX participant fn must trace cleanly.
+
+        Regression: the eager response-label validation did
+        ``np.asarray(subject_trials)``, which raised TracerArrayConversionError
+        under a JAX trace. HSSM inference differentiates through this function,
+        so it must be traceable while still validating concrete inputs (covered
+        by ``test_jax_subject_wise_function_rejects_unmapped_response_labels``).
+        """
+        jax = pytest.importorskip("jax")
+        jnp = pytest.importorskip("jax.numpy")
+
+        assembled = _make_default_config(learning_backend="jax").assemble(backend="jax")
+        compute = assembled.assemble_participant_fn(output="dict")
+        responses = jnp.asarray([-1.0, 1.0, -1.0, 1.0])
+        feedback = jnp.asarray([1.0, 0.0, 1.0, 1.0])
+
+        def loss(params):
+            rl_alpha, scaler = params
+            trials = jnp.stack(
+                [
+                    jnp.full(responses.shape, rl_alpha),
+                    jnp.full(responses.shape, scaler),
+                    responses,
+                    feedback,
+                ],
+                axis=1,
+            )
+            return jnp.sum(compute(trials)["v"])
+
+        grad = jax.grad(loss)(jnp.asarray([0.3, 2.0]))
+
+        assert np.all(np.isfinite(np.asarray(grad)))
+
     def test_jax_subject_wise_function_rejects_unmapped_response_labels(self):
         pytest.importorskip("jax.numpy")
 


### PR DESCRIPTION
## Summary

The assembled RLSSM JAX participant function (`AssembledModel.assemble_participant_fn`, JAX backend) was not differentiable: taking `jax.grad`/`jit` through it raised

```
TracerArrayConversionError: The numpy.ndarray conversion method __array__() was called on traced array with shape float32[n_trials, n_input_fields]
```

This blocks gradient-based inference (HSSM differentiates through this function via its RL likelihood Op), so RLSSM inference on `ssms.rl` models failed at the NUTS sampling step.

## Root cause

In `ssms/rl/assembled.py`, `_make_jax_subject_wise_function`'s inner `compute` calls `_validate_trial_response_labels`, which does `trials = np.asarray(subject_trials)`. That eager NumPy conversion is fine for concrete data but raises under a JAX trace, where `subject_trials` is a symbolic tracer.

## Fix

Guard the eager response-label check to skip JAX tracers (`_is_jax_tracer`). Concrete inputs are still validated (so the existing `test_jax_subject_wise_function_rejects_unmapped_response_labels` still passes), and panels are validated at the data boundary via `ModelConfig.validate_data`. The label check simply cannot run on symbolic inputs, so skipping it under tracing is correct.

## Tests

- New `test_jax_subject_wise_function_is_differentiable`: asserts `jax.grad` through the assembled JAX participant fn returns finite gradients.
- Existing concrete-input validation test retained.
- `tests/rl` → 253 passed; ruff clean.

## Impact

Enables `ssms.rl` models to be used for gradient-based inference in HSSM through the `hssm.rl.RLSSMConfig.from_ssms_model(...)` bridge (see companion HSSM PR). Verified end-to-end: a hierarchical RLSSM NUTS recovery notebook fits and recovers (group-level HDI coverage 6/6) on a bridged `2AB_RW_Angle` model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated label validation to safely bypass eager conversion when running under JAX tracing.
  * Restored differentiability for the assembled RL participant flow, ensuring gradients can be computed without errors.
* **Tests**
  * Added a JAX-focused test confirming the assembled participant function is differentiable and produces finite gradients.
  * Added a test verifying tracer-detection helper behavior when JAX is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->