### PR TITLE
fix: RLSSM mypy typing + HSSM posterior-predictive seed-range regression

### DIFF
--- a/ssms/hssm_support.py
+++ b/ssms/hssm_support.py
@@ -52,9 +52,15 @@ def _calculate_n_replicas(is_all_args_scalar, size, new_data_size):
 
 
 def _get_seed(rng):
-    """Get a seed for the random number generator."""
-    iinfo32 = np.iinfo(np.uint32)
-    return rng.integers(0, iinfo32.max, dtype=np.uint32)
+    """Draw a seed for the C-level RNG.
+
+    The seed must fit a signed 32-bit C ``long`` — i.e. ``[0, 2**31)`` — the range
+    accepted by ``simulator._validate_random_state_for_c_rng`` on all platforms
+    (Windows ``long`` is 32-bit). Drawing from the full ``uint32`` range breaches
+    that ceiling ~50% of the time, which makes the HSSM posterior-predictive path
+    (``rng_fn`` -> ``_get_seed`` -> ``simulator``) raise ``ValueError``.
+    """
+    return int(rng.integers(0, 2**31))
 
 
 def _prepare_theta_and_shape(arg_arrays, size):

--- a/ssms/rl/assembled.py
+++ b/ssms/rl/assembled.py
@@ -134,7 +134,7 @@ class AssembledModel:
             choices=tuple(config.choices),
             context_fields=list(config.context_fields) if config.context_fields else [],
             computed_params=list(config._computed_ssm_params),
-            response_to_choice=dict(config.response_to_choice),
+            response_to_choice=dict(config.resolved_response_to_choice),
         )
 
     def get_participant_input_fields(

--- a/ssms/rl/config.py
+++ b/ssms/rl/config.py
@@ -247,6 +247,20 @@ class ModelConfig:
             )
         return mapping
 
+    @property
+    def resolved_response_to_choice(self) -> dict[int, int]:
+        """Concrete response-label -> choice-index map.
+
+        ``__post_init__`` normalizes ``response_to_choice`` (including the
+        ``"auto"`` default) into a plain ``dict``; this accessor exposes that
+        post-init invariant with a narrowed type.
+        """
+        mapping = self.response_to_choice
+        assert not isinstance(mapping, str), (
+            "response_to_choice was not normalized by __post_init__"
+        )
+        return mapping
+
     def _normalize_context_fields(self) -> list[str]:
         """Derive or validate observable context fields from model components."""
         runtime_fields = {"choice", DEFAULT_RESPONSE_FIELD, "rt"}
@@ -593,7 +607,7 @@ class ModelConfig:
             "params_default": list(self.params_default),
             "choices": tuple(self.choices),
             "response": list(self.response),
-            "response_to_choice": dict(self.response_to_choice),
+            "response_to_choice": dict(self.resolved_response_to_choice),
             "learning_backend": self.resolved_learning_backend,
             "gradient": self.resolved_gradient,
             "context_fields": list(self.context_fields) if self.context_fields else [],

--- a/ssms/rl/preset.py
+++ b/ssms/rl/preset.py
@@ -99,7 +99,7 @@ def info(name: str) -> PresetInfo:
             "default_parameters": defaults,
             "bounds": dict(config.bounds),
             "response_labels": tuple(config.choices),
-            "response_to_choice": dict(config.response_to_choice),
+            "response_to_choice": dict(config.resolved_response_to_choice),
             "context_fields": (
                 builtins.list(config.context_fields) if config.context_fields else []
             ),

--- a/ssms/rl/validation.py
+++ b/ssms/rl/validation.py
@@ -303,7 +303,7 @@ def _check_response_values(
         return
 
     allowed = set(config.choices)
-    mapping_keys = set(config.response_to_choice.keys())
+    mapping_keys = set(config.resolved_response_to_choice.keys())
     subset = data.loc[valid_mask, RESPONSE_COL]
     numeric_subset = pd.to_numeric(subset, errors="coerce")
     if numeric_subset.isna().any():

--- a/tests/test_hssm_support.py
+++ b/tests/test_hssm_support.py
@@ -6,6 +6,10 @@ import numpy as np
 import pytest
 from unittest.mock import Mock, patch
 
+from ssms.basic_simulators.simulator import (
+    _RNG_SEED_C_LONG_MAX,
+    _validate_random_state_for_c_rng,
+)
 from ssms.hssm_support import (
     _extract_size_val,
     _calculate_n_replicas,
@@ -18,6 +22,7 @@ from ssms.hssm_support import (
     hssm_sim_wrapper,
     _build_decorated_simulator,
     get_simulator_fun_internal,
+    rng_fn,
     validate_simulator_fun,
 )
 
@@ -82,13 +87,23 @@ class TestCalculateNReplicas:
 class TestGetSeed:
     """Tests for _get_seed function."""
 
-    def test_get_seed_returns_uint32(self):
-        """Test that _get_seed returns a valid uint32 value."""
-        rng = np.random.default_rng(42)
-        seed = _get_seed(rng)
+    def test_get_seed_fits_signed_32bit_c_long(self):
+        """Seeds for the PPC path must fit a signed 32-bit C long on all platforms.
 
-        assert isinstance(seed, (int, np.integer))
-        assert 0 <= seed <= np.iinfo(np.uint32).max
+        Regression guard: ``_get_seed`` previously drew from the full ``uint32``
+        range ``[0, 2**32)``, but ``simulator._validate_random_state_for_c_rng``
+        rejects anything above ``2**31 - 1``. That mismatch made the HSSM
+        posterior-predictive path raise ``ValueError`` ~50% of the time. Every
+        drawn seed must both stay in range and be accepted by the validator that
+        the simulator applies to it.
+        """
+        rng = np.random.default_rng(0)
+        for _ in range(2000):
+            seed = _get_seed(rng)
+            assert isinstance(seed, (int, np.integer))
+            assert 0 <= seed <= _RNG_SEED_C_LONG_MAX
+            # The exact check the simulator performs on this seed downstream.
+            _validate_random_state_for_c_rng(seed)  # must not raise
 
     def test_get_seed_different_values(self):
         """Test that _get_seed returns different values on multiple calls."""
@@ -98,6 +113,26 @@ class TestGetSeed:
 
         # They should be different (with very high probability)
         assert seed1 != seed2
+
+    def test_rng_fn_ppc_path_never_breaches_seed_ceiling(self):
+        """End-to-end guard for the exact path HSSM uses in posterior predictives.
+
+        ``rng_fn`` draws its own seed via ``_get_seed`` and forwards it to the
+        simulator as ``random_state``. Before the fix, ~50% of these calls raised
+        ``ValueError`` because the drawn seed exceeded the C-long ceiling. Driving
+        the real path many times with a fixed generator would have failed with
+        overwhelming probability pre-fix; here it must complete cleanly.
+        """
+        simulator_fun = get_simulator_fun_internal("ddm")
+        _, _, obs_dim_int = validate_simulator_fun(simulator_fun)
+        # DDM default-ish theta (v, a, z, t) as scalar arg arrays.
+        arg_arrays = [np.array(0.0), np.array(1.5), np.array(0.5), np.array(0.1)]
+        rng = np.random.default_rng(0)
+
+        for _ in range(50):
+            out = rng_fn(arg_arrays, 5, rng, simulator_fun, obs_dim_int)
+            assert out.shape[-1] == obs_dim_int
+            assert np.isfinite(out).all()
 
 
 class TestPrepareThetaAndShape:


### PR DESCRIPTION
Two release-blocking fixes for `ssm-simulators`, surfaced during `0.12.4` release-readiness review.

## 1. HSSM posterior-predictive seed regression (the important one)

`ssms.hssm_support._get_seed` drew seeds from the full `uint32` range `[0, 2**32)`, but `simulator._validate_random_state_for_c_rng` — **added in #274, unreleased** — rejects any seed above `2**31 - 1`. The PPC path `rng_fn -> _get_seed -> simulator(random_state=...)` therefore raised `ValueError` for **~50% of draws, on every platform**.

This is a **regression vs 0.12.3**: there, a `uint32` seed worked fine on macOS/Linux (64-bit C `long`) and only overflowed on Windows. #274 fixed the Windows overflow by adding a Python-level `ValueError` that fires everywhere, but didn't update `_get_seed` — converting a Windows-only crash into an all-platform one in the HSSM PPC path.

**Fix:** draw from `[0, 2**31)`, matching `simulator._get_unique_seed` and the validated range. Reproduced before (50.0% breach over 100k draws) and after (0.0%).

**Why CI stayed green:** the two seed generators were tested against *different* contracts. `test_get_seed_returns_uint32` asserted the wide `uint32` bound (encoding the bug); #274 only tested the *other* generator (`_get_unique_seed`) and the validator in isolation. No test spanned `_get_seed -> validator` or the `rng_fn` integration path.

**Tests added/fixed:**
- Rewrote the stale `_get_seed` unit test to assert the in-range contract *and* that every drawn seed passes the simulator's own validator.
- Added an end-to-end `rng_fn` PPC-path test (drives the real `get_simulator_fun_internal("ddm")` path 50×) that would have failed with overwhelming probability pre-fix.

## 2. RLSSM mypy typing

`ModelConfig.response_to_choice` is declared `Literal["auto"] | dict[int, int]` (constructor input) but `__post_init__` normalizes it to a concrete `dict`. mypy couldn't see that, so four sites failed the pre-commit `mypy` hook. Added a typed `resolved_response_to_choice` accessor and routed the four sites through it. No behavior change.

## Verification
- `mypy --no-strict-optional --ignore-missing-imports ssms/`: **0 errors**
- `ruff check` + `ruff format --check`: clean
- `pytest tests/test_hssm_support.py tests/test_simulator.py`: 75 passed; `tests/rl/`: 255 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)