### PR TITLE
Add plain four-choice LBA config

### DIFF
--- a/ssms/config/_modelconfig/__init__.py
+++ b/ssms/config/_modelconfig/__init__.py
@@ -74,6 +74,7 @@ from .gamma_drift import (
 from .lba import (
     get_lba2_config,
     get_lba3_config,
+    get_lba4_config,
     get_lba_3_vs_constraint_config,
     get_lba_angle_3_config,
     get_lba_angle_3_vs_constraint_config,
@@ -271,6 +272,7 @@ def get_model_config():
         "dev_rlwm_lba_race_v2": get_dev_rlwm_lba_race_v2_config(),
         "lba2": get_lba2_config(),
         "lba3": get_lba3_config(),
+        "lba4": get_lba4_config(),
         "lba_3_vs_constraint": get_lba_3_vs_constraint_config(),
         "lba_angle_3_vs_constraint": get_lba_angle_3_vs_constraint_config(),
         "lba_angle_3": get_lba_angle_3_config(),

--- a/ssms/config/_modelconfig/lba.py
+++ b/ssms/config/_modelconfig/lba.py
@@ -27,6 +27,8 @@ _SET_ZERO_T = LambdaAdaptation(
     name="set_zero_t",
 )
 
+_LBA_START_THRESHOLD_SAMPLING_TRANSFORMS = [SwapIfLessConstraint("b", "A")]
+
 # LBA2 simulation transforms
 _LBA2_SIMULATION_TRANSFORMS = [
     LambdaAdaptation(
@@ -101,7 +103,7 @@ def get_lba2_config():
         "n_particles": 2,
         "simulator": cssm.lba_vanilla,
         "parameter_transforms": {
-            "sampling": [],
+            "sampling": _LBA_START_THRESHOLD_SAMPLING_TRANSFORMS,
             "simulation": _LBA2_SIMULATION_TRANSFORMS,
         },
     }
@@ -122,7 +124,7 @@ def get_lba3_config():
         "n_particles": 3,
         "simulator": cssm.lba_vanilla,
         "parameter_transforms": {
-            "sampling": [],
+            "sampling": _LBA_START_THRESHOLD_SAMPLING_TRANSFORMS,
             "simulation": _LBA3_SIMULATION_TRANSFORMS,
         },
     }
@@ -146,7 +148,7 @@ def get_lba4_config():
         "n_particles": 4,
         "simulator": cssm.lba_vanilla,
         "parameter_transforms": {
-            "sampling": [],
+            "sampling": _LBA_START_THRESHOLD_SAMPLING_TRANSFORMS,
             "simulation": _LBA4_SIMULATION_TRANSFORMS,
         },
     }

--- a/ssms/config/_modelconfig/lba.py
+++ b/ssms/config/_modelconfig/lba.py
@@ -53,6 +53,19 @@ _LBA3_SIMULATION_TRANSFORMS = [
     _SET_ZERO_T,
 ]
 
+# LBA4 simulation transforms
+_LBA4_SIMULATION_TRANSFORMS = [
+    LambdaAdaptation(
+        lambda theta, cfg, n: theta.update({"nact": 4}) or theta,
+        name="set_nact_4",
+    ),
+    ColumnStackParameters(["v0", "v1", "v2", "v3"], "v", delete_sources=False),
+    RenameParameter("A", "z", lambda x: np.expand_dims(x, axis=1)),
+    RenameParameter("b", "a", lambda x: np.expand_dims(x, axis=1)),
+    DeleteParameters(["A", "b"]),
+    _SET_ZERO_T,
+]
+
 # LBA 3-choice with vs constraint simulation transforms (non-angle)
 _LBA_3_VS_CONSTRAINT_SIMULATION_TRANSFORMS = [
     ColumnStackParameters(["v0", "v1", "v2"], "v", delete_sources=False),
@@ -111,6 +124,30 @@ def get_lba3_config():
         "parameter_transforms": {
             "sampling": [],
             "simulation": _LBA3_SIMULATION_TRANSFORMS,
+        },
+    }
+
+
+def get_lba4_config():
+    """Get configuration for LBA4 model."""
+    return {
+        "name": "lba4",
+        "params": ["A", "b", "v0", "v1", "v2", "v3"],
+        "param_bounds": [
+            [0.0, 0.0, 0.0, 0.1, 0.1, 0.1],
+            [1.0, 1.0, 1.0, 1.1, 0.50, 0.50],
+        ],
+        "boundary_name": "constant",
+        "boundary": bf.constant,
+        "n_params": 6,
+        "default_params": [0.3, 0.5, 0.25, 0.25, 0.25, 0.25],
+        "nchoices": 4,
+        "choices": [0, 1, 2, 3],
+        "n_particles": 4,
+        "simulator": cssm.lba_vanilla,
+        "parameter_transforms": {
+            "sampling": [],
+            "simulation": _LBA4_SIMULATION_TRANSFORMS,
         },
     }
 

--- a/tests/config/test_registries.py
+++ b/tests/config/test_registries.py
@@ -204,6 +204,7 @@ class TestModelConfigRegistry:
         assert "ddm" in models
         assert "angle" in models
         assert "ornstein" in models
+        assert "lba4" in models
         assert len(models) >= 100  # Should have 106 models
 
     def test_register_custom_model_config(self):

--- a/tests/data_generator/test_data_generator.py
+++ b/tests/data_generator/test_data_generator.py
@@ -78,15 +78,12 @@ broken_models = [
     "lba_3_vs_constraint",  # broken
     "lba_angle_3_vs_constraint",  # broken
     "dev_rlwm_lba_race_v2",  # broken
-    "lba2",  # broken - generates incorrect number of parameter sets
 ]
 
 # Ultra slow models, likely broken?
 slow_prefixes = (
     "race",
     "dev_rlwm",
-    "lba3",
-    "lba_angle_3",
     "lca",
     "ddm_par2",
     "ddm_seq2",

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -99,6 +99,20 @@ class TestModelConfigBuilder:
         assert "v1" in config["params"]
         assert "v2" in config["params"]
 
+    def test_lba4_config(self):
+        """Test plain 4-choice LBA model config."""
+        config = ModelConfigBuilder.from_model("lba4")
+
+        assert config["name"] == "lba4"
+        assert config["params"] == ["A", "b", "v0", "v1", "v2", "v3"]
+        assert config["n_params"] == 6
+        assert config["default_params"] == [0.3, 0.5, 0.25, 0.25, 0.25, 0.25]
+        assert config["nchoices"] == 4
+        assert config["choices"] == [0, 1, 2, 3]
+        assert config["n_particles"] == 4
+        assert "param_bounds_dict" in config
+        assert set(config["param_bounds_dict"]) == set(config["params"])
+
     def test_model_config_builder_preserves_structure(self):
         """Test that builder preserves all expected config fields."""
         config = ModelConfigBuilder.from_model("ddm")

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -4,6 +4,7 @@ import numpy as np
 import ssms
 from ssms.config import model_config
 from ssms.config.model_config_builder import ModelConfigBuilder
+from ssms.transforms import SwapIfLessConstraint
 
 
 class TestModelConfig:
@@ -112,6 +113,26 @@ class TestModelConfigBuilder:
         assert config["n_particles"] == 4
         assert "param_bounds_dict" in config
         assert set(config["param_bounds_dict"]) == set(config["params"])
+
+    @pytest.mark.parametrize("model_name", ["lba2", "lba3", "lba4"])
+    def test_plain_lba_sampling_enforces_threshold_above_start(self, model_name):
+        """Test plain LBA sampling keeps public threshold b above start range A."""
+        config = ModelConfigBuilder.from_model(model_name)
+        transforms = ModelConfigBuilder.get_sampling_transforms(config)
+
+        assert len(transforms) == 1
+        transform = transforms[0]
+        assert isinstance(transform, SwapIfLessConstraint)
+        assert transform.param_a == "b"
+        assert transform.param_b == "A"
+
+        theta = {
+            "A": np.array([0.8, 0.2], dtype=np.float32),
+            "b": np.array([0.3, 0.7], dtype=np.float32),
+        }
+        transformed = transform.apply(theta)
+
+        assert np.all(transformed["b"] > transformed["A"])
 
     def test_model_config_builder_preserves_structure(self):
         """Test that builder preserves all expected config fields."""

--- a/tests/test_simulator_class.py
+++ b/tests/test_simulator_class.py
@@ -219,6 +219,26 @@ class TestSimulation:
         np.testing.assert_array_equal(results1["rts"], results2["rts"])
         np.testing.assert_array_equal(results1["choices"], results2["choices"])
 
+    def test_lba4_simulation(self):
+        """Test plain 4-choice LBA simulation."""
+        sim = Simulator("lba4")
+        theta = {
+            "A": 0.3,
+            "b": 0.5,
+            "v0": 0.25,
+            "v1": 0.25,
+            "v2": 0.25,
+            "v3": 0.25,
+        }
+
+        results = sim.simulate(theta=theta, n_samples=100, random_state=42)
+
+        assert "rts" in results
+        assert "choices" in results
+        assert "metadata" in results
+        assert results["metadata"]["possible_choices"] == [0, 1, 2, 3]
+        assert np.all(np.isin(results["choices"], [0, 1, 2, 3]))
+
 
 class TestModelConfigBuilder:
     """Test ModelConfigBuilder utility class."""


### PR DESCRIPTION
## Summary
- add built-in plain `lba4` model config using the existing generic LBA simulator backend
- register `lba4` through `get_model_config()` and the built-in registry
- add plain LBA sampling constraints for `lba2`, `lba3`, and `lba4` so generated LAN/KDE parameter draws keep public threshold `b` above start range `A`
- restore generator-test coverage for `lba2`, `lba3`, `lba4`, and `lba_angle_3`
- cover config normalization, registry visibility, `Simulator("lba4")` choices/metadata, and the plain-LBA sampling transform contract

## CI Follow-Up
- Initial CI failed in `run_tests` for Python 3.11-3.14 on `tests/data_generator/test_data_generator.py::test_TrainingDataGenerator[lba4-model_conf88]`.
- Root cause: plain LBA configs sampled `A` and `b` independently, but simulation maps `A -> z` and `b -> a`; invalid `b <= A` draws were rejected, leaving fewer generated parameter sets than the test expected.
- Fix: use `SwapIfLessConstraint("b", "A")` for plain `lba2`, `lba3`, and `lba4` sampling, and remove the now-covered LBA models from generator-test skip prefixes/lists.

## Verification
- `uv run pytest tests/test_model_config.py tests/config/test_registries.py tests/test_simulator_class.py tests/test_simulator.py -q`
- `uv run pytest tests/test_model_config.py tests/data_generator/test_data_generator.py::test_TrainingDataGenerator tests/test_simulator_class.py::TestSimulation::test_lba4_simulation -q`
- `uv run pytest`
- `uv run pytest tests/data_generator/test_data_generator.py::test_TrainingDataGenerator -q`
- `uv run ruff check ssms/config/_modelconfig/lba.py ssms/config/_modelconfig/__init__.py tests/test_model_config.py tests/config/test_registries.py tests/test_simulator_class.py`
- `uv run ruff check ssms/config/_modelconfig/lba.py tests/data_generator/test_data_generator.py tests/test_model_config.py`

## Ecosystem Notes
- Producer PR for HSSM `lba4` support in lnccbrown/HSSM#1042. HSSM can use the analytical likelihood independently, but `hssm.simulate_data("lba4", ...)` depends on this simulator support being merged/released.
- Plain `lba4` only; angle and constrained LBA4 variants are out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new 4-choice LBA model configuration.
  * Simulations now return four possible choices with matching metadata and parameter setup.

* **Tests**
  * Expanded registry, configuration, and simulation coverage to include the new 4-choice model.
  * Added checks to confirm expected defaults, bounds, and valid choice outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
