### PR TITLE
test(addm): cover new code paths flagged by codecov on #266

### DIFF
--- a/tests/test_addm_simulator.py
+++ b/tests/test_addm_simulator.py
@@ -542,3 +542,28 @@ def test_fixation_continuation_module_strategies():
 
     n2, _, _, _ = fc.resample_all_fixations(node, d, flag, 5.0, p, rng)
     assert bool((n2[:, 0] == 0.0).all())  # fresh schedule anchored at 0.0
+
+
+def test_fixation_continuation_resolvers_and_require_dist():
+    """Resolver seam (callable passthrough / bad type) + the _require_dist guard."""
+    from ssms.basic_simulators import fixation_continuation as fc
+
+    rng = np.random.default_rng(0)
+    node = np.array([[0.0, 0.3, 0.7]])
+    d = np.array([3], dtype=np.int32)
+    flag = np.array([0], dtype=np.int64)
+
+    # sample_continuation / resample_all_fixations require continuation_params w/ a 'dist'.
+    with pytest.raises(ValueError):
+        fc.sample_continuation(node, d, flag, 5.0, None, rng)
+    with pytest.raises(ValueError):
+        fc.resample_all_fixations(node, d, flag, 5.0, {"dist_params": {}}, rng)
+
+    # resolve_continuation_mode: a callable is returned as-is (pluggable-strategy seam) ...
+    assert (
+        fc.resolve_continuation_mode(fc.prolong_last_fixation)
+        is fc.prolong_last_fixation
+    )
+    # ... and a non-str / non-callable is rejected loudly.
+    with pytest.raises(TypeError):
+        fc.resolve_continuation_mode(123)

--- a/tests/test_hssm_support.py
+++ b/tests/test_hssm_support.py
@@ -11,6 +11,7 @@ from ssms.basic_simulators.simulator import (
     _validate_random_state_for_c_rng,
 )
 from ssms.hssm_support import (
+    _broadcast_extra_fields,
     _extract_size_val,
     _calculate_n_replicas,
     _get_seed,
@@ -481,3 +482,44 @@ class TestValidateSimulatorFun:
             ValueError, match="The obs_dim attribute must be an integer"
         ):
             validate_simulator_fun(mock_simulator)
+
+
+class TestExtraFieldsBroadcast:
+    """Covariate (extra_fields) broadcasting for the vector-parameter path (aDDM PPC)."""
+
+    def test_broadcast_extra_fields_aligns_and_passes_through(self):
+        """Per-trial covariates tile across leading dims; scalar / mismatched pass through."""
+        ef = {
+            "r1": np.array([4.0, 5.0, 6.0]),  # per-trial -> broadcast to theta rows
+            "sigma": np.float64(1.0),  # 0-d scalar -> unchanged
+            "other": np.array([1.0, 2.0]),  # wrong length -> unchanged
+        }
+        out = _broadcast_extra_fields(ef, max_shape=(2, 3), new_data_size=3)
+        # (2 leading replicas x 3 trials) flattens with trial = i % 3, matching theta.
+        assert np.array_equal(out["r1"], np.array([4.0, 5.0, 6.0, 4.0, 5.0, 6.0]))
+        assert np.ndim(out["sigma"]) == 0
+        assert np.array_equal(out["other"], np.array([1.0, 2.0]))
+
+    def test_rng_fn_broadcasts_extra_fields_for_vector_theta(self):
+        """rng_fn triggers the covariate broadcast on the non-scalar path and forwards it."""
+        captured = {}
+
+        class _Stop(Exception):
+            pass
+
+        def stub(theta, random_state, n_replicas, **kwargs):
+            captured["theta_rows"] = theta.shape[0]
+            captured["extra_fields"] = kwargs.get("extra_fields")
+            raise _Stop  # bail before the reshape; we only assert the broadcast
+
+        arg_arrays = [
+            np.full((2, 3), 0.1),
+            np.full((2, 3), 1.0),
+        ]  # vector theta, 3 trials
+        ef = {"r1": np.array([4.0, 5.0, 6.0]), "sigma": np.float64(1.0)}
+        rng = np.random.default_rng(0)
+        with pytest.raises(_Stop):
+            rng_fn(arg_arrays, None, rng, stub, 2, extra_fields=ef)
+        # per-trial covariate broadcast to match theta's flattened rows; scalar untouched.
+        assert captured["extra_fields"]["r1"].shape[0] == captured["theta_rows"]
+        assert np.ndim(captured["extra_fields"]["sigma"]) == 0


### PR DESCRIPTION
Fixes the codecov patch-coverage complaint on #266 by covering the 15 uncovered new Python lines with focused, meaningful tests (no padding; no blanket pragmas — the defensive `__main__`/`NotImplementedError` lines are already excluded by `[tool.coverage.report]`).

**What's covered**
- `fixation_continuation.py`: the `_require_dist` guard (sample/resample continuation require a `dist`), `resolve_continuation_mode`'s callable-passthrough seam, and its bad-type `TypeError`.
- `hssm_support.py`: a direct `_broadcast_extra_fields` unit test (per-trial broadcast + scalar/mismatched pass-through, asserting `i % n_trials` row-alignment) and an `rng_fn` dispatch test proving the vector-theta path broadcasts `extra_fields` before forwarding to the simulator.

Patch coverage of new aDDM Python lines: **74/74**. Test-only, no source changes.

Stacked on #266 — merge into `addm-sim` and #266's codecov turns green.