### PR TITLE
Prepare 0.13.0 release metadata

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v4.1.0
         env:
-          CIBW_BUILD: cp311-* cp312-* cp313-* cp314-*
+          CIBW_BUILD: cp312-* cp313-* cp314-*
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_LINUX: auto64
           CIBW_ARCHS_WINDOWS: auto64

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -87,16 +87,9 @@ Install the optional JAX backend for differentiable RLSSM learning processes:
 pip install "ssm-simulators[jax]"
 ```
 
-For full parallel support, conda-forge is the easiest route because OpenMP and
-GSL are included:
-
-```sh
-conda install -c conda-forge ssm-simulators
-```
-
 > [!NOTE]
 > Multi-threaded simulation with `n_threads > 1` requires OpenMP and GSL.
-> With `pip`, install system dependencies first:
+> Install system dependencies first:
 >
 > ```bash
 > # macOS

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ![PyPI](https://img.shields.io/pypi/v/ssm-simulators)
 ![PyPI_dl](https://img.shields.io/pypi/dm/ssm-simulators)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/lnccbrown/ssm-simulators)](https://github.com/lnccbrown/ssm-simulators/pulls)
-![Python Version](https://img.shields.io/pypi/pyversions/ssm-simulators)
+[![Python Version](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/ssm-simulators/)
 [![Run tests](https://img.shields.io/github/actions/workflow/status/lnccbrown/ssm-simulators/run_tests.yml?branch=main&label=tests)](https://github.com/lnccbrown/ssm-simulators/actions/workflows/run_tests.yml)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -96,13 +96,12 @@ pip install "ssm-simulators[jax]"
 > brew install libomp gsl
 >
 > # Ubuntu/Debian
-> sudo apt-get install libgomp-dev libgsl-dev
+> sudo apt-get install build-essential libgsl-dev
 > ```
 >
 > Then reinstall with `pip install --force-reinstall ssm-simulators`.
 > Without these dependencies, the package still works in single-threaded mode.
-
-> [!NOTE]
+>
 > Building from source or developing this package requires a C compiler. Most
 > users installing from PyPI wheels do not need to install GCC manually.
 
@@ -173,7 +172,7 @@ The package exposes `generate` for creating training data from a YAML
 configuration file:
 
 ```bash
-generate --config-path <path/to/config.yaml> --output <output/directory> [--log-level INFO]
+generate [--config-path <path/to/config.yaml>] --output <output/directory> [--log-level INFO]
 ```
 
 Common options:

--- a/README.md
+++ b/README.md
@@ -17,17 +17,67 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![codecov](https://codecov.io/gh/lnccbrown/ssm-simulators/branch/main/graph/badge.svg)](https://codecov.io/gh/lnccbrown/ssm-simulators)
 
-Python Package to collect simulators for Sequential Sampling Models.
+`ssm-simulators` provides fast C/Cython simulators for sequential sampling
+models used in cognitive science, neuroscience, and amortized Bayesian
+inference, spanning classic DDM variants, multi-choice models, attention
+models, and reinforcement-learning SSMs.
 
 Find the package documentation [here](https://lnccbrown.github.io/ssm-simulators/).
 
 
+### What can I simulate?
+
+Use `ssm-simulators` when you need to:
+
+- Simulate response-time and choice data from a broad library of sequential
+  sampling models.
+- Generate training data for likelihood approximation networks and other
+  amortized-inference workflows.
+- Prototype new SSM variants with custom drift functions, boundary functions,
+  parameter transforms, and high-performance Cython extensions.
+- Work with reinforcement-learning SSMs, including Rescorla-Wagner learning
+  rules and choice-only inverse-temperature softmax models.
+
+Model families include:
+
+- **Diffusion models**: DDM, full DDM, deadline variants, flexible-boundary DDMs
+  with angle and Weibull boundaries, Levy models, Ornstein-Uhlenbeck models,
+  gamma-drift models, conflict models, tradeoff models, and shrink-spotlight
+  variants.
+- **Multi-choice accumulators**: race models, racing diffusion models, LBA
+  models including two-, three-, and four-choice variants, LCA models, and
+  Poisson race models.
+- **Attention and fixation-conditioned models**: aDDM simulators with observed
+  or self-sampled fixation inputs, continuation strategies, and optional
+  trajectory metadata for visualization.
+- **Reinforcement-learning SSMs**: ssms-defined RL task presets, learning rules,
+  participant replay functions, RT+choice models, and choice-only softmax
+  decision processes.
+
+### Where it fits
+
+`ssm-simulators` is the simulator and data-generation layer of the HSSM
+ecosystem. It is used by [LANfactory](https://github.com/lnccbrown/LANfactory)
+and [LAN_pipeline_minimal](https://github.com/lnccbrown/LAN_pipeline_minimal)
+to generate training data for likelihood networks, and by
+[HSSM](https://github.com/lnccbrown/HSSM) to bridge simulator-defined model
+configurations into Bayesian inference workflows.
+
 ### Quick Start
 
-The `ssms` package serves two purposes.
+The `Simulator` class is the recommended user-facing API for direct simulation:
 
-1. Easy access to *fast simulators of sequential sampling models*
-2. Support infrastructure to construct training data for various approaches to likelihood / posterior amortization
+```python
+from ssms.basic_simulators import Simulator
+
+sim = Simulator("ddm")
+out = sim.simulate(
+    theta={"v": 1.0, "a": 1.5, "z": 0.5, "t": 0.2},
+    n_samples=1000,
+)
+
+print(out["rts"].shape, out["choices"].shape)
+```
 
 A number of tutorial notebooks are available under the `/notebooks` directory.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   </a>
 </div>
 
-## SSMS (Sequential Sampling Model Simulators)
+# SSMS: Sequential Sampling Model Simulators
 
 [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.17156205-blue)](https://doi.org/10.5281/zenodo.17156205)
 ![PyPI](https://img.shields.io/pypi/v/ssm-simulators)
@@ -22,48 +22,102 @@ models used in cognitive science, neuroscience, and amortized Bayesian
 inference, spanning classic DDM variants, multi-choice models, attention
 models, and reinforcement-learning SSMs.
 
-Find the package documentation [here](https://lnccbrown.github.io/ssm-simulators/).
+---
 
+## At a Glance
 
-### What can I simulate?
+| Need | Use ssms for |
+| --- | --- |
+| Simulate behavior | Generate response-time and choice data from a broad SSM library. |
+| Train likelihood networks | Produce LAN/LANfactory-style training data with configurable simulators and KDE estimators. |
+| Prototype models | Combine registered model configs, custom drift/boundary functions, parameter transforms, and Cython extensions. |
+| Work with RLSSMs | Simulate trial-wise learning models, response-only choice models, and posterior predictive functions for RL workflows. |
 
-Use `ssm-simulators` when you need to:
+Core links:
 
-- Simulate response-time and choice data from a broad library of sequential
-  sampling models.
-- Generate training data for likelihood approximation networks and other
-  amortized-inference workflows.
-- Prototype new SSM variants with custom drift functions, boundary functions,
-  parameter transforms, and high-performance Cython extensions.
-- Work with reinforcement-learning SSMs, including Rescorla-Wagner learning
-  rules and choice-only inverse-temperature softmax models.
+- Documentation: <https://lnccbrown.github.io/ssm-simulators/>
+- API reference: <https://lnccbrown.github.io/ssm-simulators/api/ssms/>
+- RLSSM API: <https://lnccbrown.github.io/ssm-simulators/api/rlssm/>
+- Issues and feature requests: <https://github.com/lnccbrown/ssm-simulators/issues>
 
-Model families include:
+---
 
-- **Diffusion models**: DDM, full DDM, deadline variants, flexible-boundary DDMs
-  with angle and Weibull boundaries, Levy models, Ornstein-Uhlenbeck models,
-  gamma-drift models, conflict models, tradeoff models, and shrink-spotlight
-  variants.
-- **Multi-choice accumulators**: race models, racing diffusion models, LBA
-  models including two-, three-, and four-choice variants, LCA models, and
-  Poisson race models.
-- **Attention and fixation-conditioned models**: aDDM simulators with observed
-  or self-sampled fixation inputs, continuation strategies, and optional
-  trajectory metadata for visualization.
-- **Reinforcement-learning SSMs**: ssms-defined RL task presets, learning rules,
-  participant replay functions, RT+choice models, and choice-only softmax
-  decision processes.
+## Model Coverage
 
-### Where it fits
+| Family | Examples |
+| --- | --- |
+| Diffusion models | DDM, full DDM, deadline variants, angle and Weibull boundaries, Levy, Ornstein-Uhlenbeck, gamma-drift, conflict, tradeoff, and shrink-spotlight variants. |
+| Multi-choice accumulators | Race, racing diffusion, LBA, LBA4, LCA, and Poisson race models. |
+| Attention models | aDDM with observed or self-sampled fixations, continuation strategies, and optional trajectory metadata. |
+| Reinforcement-learning SSMs | Rescorla-Wagner learning rules, RT + choice RLSSMs, inverse-temperature softmax choice-only models, and response-only posterior predictive workflows. |
+
+Choice-only RL support includes inverse-temperature softmax decision processes
+for two-, three-, and four-choice settings. Built-in RL presets currently cover
+two- and three-armed Rescorla-Wagner bandits:
+`2AB_RW_InvTempSoftmax` and `3AB_RW_InvTempSoftmax`.
+
+---
+
+## Where ssms Fits
 
 `ssm-simulators` is the simulator and data-generation layer of the HSSM
-ecosystem. It is used by [LANfactory](https://github.com/lnccbrown/LANfactory)
-and [LAN_pipeline_minimal](https://github.com/lnccbrown/LAN_pipeline_minimal)
-to generate training data for likelihood networks, and by
-[HSSM](https://github.com/lnccbrown/HSSM) to bridge simulator-defined model
-configurations into Bayesian inference workflows.
+ecosystem.
 
-### Quick Start
+| Package | Relationship |
+| --- | --- |
+| [HSSM](https://github.com/lnccbrown/HSSM) | Builds Bayesian inference workflows around simulator-defined model configurations, including ssms-defined RLSSMs. |
+| [LANfactory](https://github.com/lnccbrown/LANfactory) | Trains likelihood approximation networks from ssms-generated simulation data. |
+| [LAN_pipeline_minimal](https://github.com/lnccbrown/LAN_pipeline_minimal) | Orchestrates simulation and LAN training pipelines. |
+
+The RLSSM path is ssms-first: ssms owns the learning rule, task environment,
+response mapping, and simulator/PPC behavior; HSSM consumes the assembled model
+contract through `hssm.rl.RLSSMConfig.from_ssms_model(...)` for inference.
+
+---
+
+## Installation
+
+```sh
+pip install ssm-simulators
+```
+
+Install the optional JAX backend for differentiable RLSSM learning processes:
+
+```sh
+pip install "ssm-simulators[jax]"
+```
+
+For full parallel support, conda-forge is the easiest route because OpenMP and
+GSL are included:
+
+```sh
+conda install -c conda-forge ssm-simulators
+```
+
+> [!NOTE]
+> Multi-threaded simulation with `n_threads > 1` requires OpenMP and GSL.
+> With `pip`, install system dependencies first:
+>
+> ```bash
+> # macOS
+> brew install libomp gsl
+>
+> # Ubuntu/Debian
+> sudo apt-get install libgomp-dev libgsl-dev
+> ```
+>
+> Then reinstall with `pip install --force-reinstall ssm-simulators`.
+> Without these dependencies, the package still works in single-threaded mode.
+
+> [!NOTE]
+> Building from source or developing this package requires a C compiler. Most
+> users installing from PyPI wheels do not need to install GCC manually.
+
+---
+
+## Quick Starts
+
+### Classic SSM Simulation
 
 The `Simulator` class is the recommended user-facing API for direct simulation:
 
@@ -79,98 +133,71 @@ out = sim.simulate(
 print(out["rts"].shape, out["choices"].shape)
 ```
 
-A number of tutorial notebooks are available under the `/notebooks` directory.
+### RLSSM Simulation
 
-#### Installation
-
-```sh
-pip install ssm-simulators
-```
-
-Install the optional JAX backend for differentiable RLSSM learning processes:
-
-```sh
-pip install "ssm-simulators[jax]"
-```
-
-**Recommended: Install via conda-forge for full parallel support:**
-
-```sh
-conda install -c conda-forge ssm-simulators
-```
-
-> [!NOTE]
-> **Parallel Execution Requirements:**
->
-> For multi-threaded simulation (`n_threads > 1`), the package requires:
-> - **OpenMP**: For parallel loop execution
-> - **GSL (GNU Scientific Library)**: For validated random number generation
->
-> **conda-forge users**: Both dependencies are automatically included.
->
-> **pip users**: Install system dependencies first:
-> ```bash
-> # macOS
-> brew install libomp gsl
->
-> # Ubuntu/Debian
-> sudo apt-get install libgomp-dev libgsl-dev
-> ```
-> Then reinstall: `pip install --force-reinstall ssm-simulators`
->
-> Without these dependencies, the package works in single-threaded mode using NumPy.
-
-> [!NOTE]
-> Building from source or developing this package requires a C compiler (such as GCC).
-> On Linux, you can install GCC with:
-> ```bash
-> sudo apt-get install build-essential
-> ```
-> Most users installing from PyPI wheels do **not** need to install GCC.
-
-#### Parallel Execution Details
-
-When using `n_threads > 1`, the package uses GSL's validated Ziggurat algorithm for
-Gaussian random number generation, ensuring statistically correct simulations.
-
-**Thread Limit**: The maximum supported number of threads is **256** (compile-time limit).
-Requesting more threads will raise a `ValueError`. This limit exists because per-thread
-random number generator states are allocated as static arrays for performance.
+RLSSMs combine a trial-wise learning process, a task environment, and an SSM or
+choice-only decision process:
 
 ```python
-from ssms.basic_simulators import simulator
+import ssms.rl as rl
 
-# Single-threaded (uses NumPy RNG)
-result = simulator.simulator(model='ddm', theta=theta, n_samples=10000, n_threads=1)
+config = rl.preset.get("2AB_RW_InvTempSoftmax")
+sim = rl.Simulator(config)
 
-# Multi-threaded (uses GSL Ziggurat RNG, requires OpenMP + GSL)
-result = simulator.simulator(model='ddm', theta=theta, n_samples=10000, n_threads=8)
+data = sim.simulate(
+    theta={"rl_alpha": 0.2, "beta": 2.0},
+    n_trials=200,
+    n_participants=20,
+    random_state=42,
+)
+
+response_only = data.drop(columns=["rt"])
+config.validate_data(response_only).raise_for_errors()
 ```
 
-Check your installation's parallel capabilities:
-```python
-from cssm._openmp_status import print_status
-print_status()
-```
+For choice-only models, the simulator keeps `rt=-1.0` only as a compatibility
+placeholder in generative output. HSSM inference and ssms PPC use response-only
+data.
 
-#### Command Line Interface
-The package exposes a command-line tool, `generate`, for creating training data from a YAML configuration file.
+---
+
+## Tutorials
+
+Start here:
+
+- [Basic tutorial](https://lnccbrown.github.io/ssm-simulators/basic_tutorial/basic_tutorial/)
+- [Package overview](https://lnccbrown.github.io/ssm-simulators/core_tutorials/tutorial_capabilities/)
+- [RLSSM tutorial](https://lnccbrown.github.io/ssm-simulators/core_tutorials/rlssm_tutorial/)
+- [RLSSM simulation and HSSM handoff](https://lnccbrown.github.io/ssm-simulators/core_tutorials/rlssm_simulation_hssm_handoff/)
+- [Choice-only RL models](https://lnccbrown.github.io/ssm-simulators/core_tutorials/choice_only_rl_models/)
+- [Contributing new models](https://lnccbrown.github.io/ssm-simulators/contributing/add_models/)
+
+---
+
+## Training Data CLI
+
+The package exposes `generate` for creating training data from a YAML
+configuration file:
 
 ```bash
 generate --config-path <path/to/config.yaml> --output <output/directory> [--log-level INFO]
 ```
 
-- `--config-path`: Path to your YAML configuration file (optional, uses default if not provided).
-- `--output`: Directory where generated data will be saved (required).
-- `--n-files`: (Optional) Number of data files to generate. Default is `1` file.
-- `--estimator-type`: (Optional) Likelihood estimator type (`kde` or `pyddm`). Overrides YAML config if specified.
-- `--log-level`: (Optional) Set the logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). Default is `WARNING`.
+Common options:
 
-Below is a sample YAML configuration you can use with the `generate` command:
+| Option | Meaning |
+| --- | --- |
+| `--config-path` | YAML configuration path. Uses the default config if omitted. |
+| `--output` | Output directory for generated data. |
+| `--n-files` | Number of data files to generate. |
+| `--estimator-type` | Likelihood estimator override, such as `kde` or `pyddm`. |
+| `--log-level` | Logging level. |
+
+Minimal YAML example:
 
 ```yaml
-MODEL: 'ddm'
-GENERATOR_APPROACH: 'lan'
+MODEL: "ddm"
+GENERATOR_APPROACH: "lan"
 
 PIPELINE:
   N_PARAMETER_SETS: 100
@@ -184,129 +211,76 @@ TRAINING:
   N_SAMPLES_PER_PARAM: 200
 
 ESTIMATOR:
-  TYPE: 'kde'  # Options: 'kde' (default) or 'pyddm'
+  TYPE: "kde"
 ```
 
-Configuration file parameter details follow.
+---
 
-**Top-Level Parameters:**
-| Option | Definition |
-| ------ | ---------- |
-| `MODEL` | The type of model you want to simulate (e.g., `ddm`, `angle`, `levy`) |
-| `GENERATOR_APPROACH` | Type of generator used to generate data (`lan` or `cpn`) |
+## Parallel Execution
 
-**PIPELINE Section:**
-| Option | Definition |
-| ------ | ---------- |
-| `N_PARAMETER_SETS` | Number of parameter vectors that are used for training |
-| `N_SUBRUNS` | Number of repetitions of each call to generate data |
-
-**SIMULATOR Section:**
-| Option | Definition |
-| ------ | ---------- |
-| `N_SAMPLES` | Number of samples a simulation run should entail for a given parameter set |
-| `DELTA_T` | Time discretization step used in numerical simulation of the model. Interval between updates of evidence-accumulation. |
-
-**TRAINING Section:**
-| Option | Definition |
-| ------ | ---------- |
-| `N_SAMPLES_PER_PARAM` | Number of times the kernel density estimate (KDE) is evaluated after creating the KDE from simulations of each set of model parameters |
-
-**ESTIMATOR Section:**
-| Option | Definition |
-| ------ | ---------- |
-| `TYPE` | Likelihood estimator type: `kde` (default) or `pyddm` |
-
-To make your own configuration file, you can copy the example above into a new `.yaml` file and modify it with your preferences.
-
-If you are using `uv` (see below), you can use the `uv run` command to run `generate` from the command line
-
-This will generate training data according to your configuration and save it in the specified output directory.
-
-### Key Features
-
-#### Custom Parameter Transforms
-
-Register custom transformations to apply model-specific modifications to sampled parameters:
+When using `n_threads > 1`, ssms uses GSL's validated Ziggurat algorithm for
+Gaussian random number generation. The maximum supported number of threads is
+256.
 
 ```python
-from ssms import register_transform_function
-import numpy as np
+from ssms.basic_simulators import Simulator
 
-# Register a custom transform
-def exponential_drift(theta: dict) -> dict:
-    if 'v' in theta:
-        theta['v'] = np.exp(theta['v'])
-    return theta
+theta = {"v": 1.0, "a": 1.5, "z": 0.5, "t": 0.2}
 
-register_transform_function("exp_v", exponential_drift)
-
-# Use in model configuration
-model_config = {
-    "name": "my_model",
-    "params": ["v", "a", "z", "t"],
-    "param_bounds": [...],
-    "parameter_transforms": [
-        {"type": "exp_v"}  # Your custom transform
-    ]
-}
+sim = Simulator("ddm")
+single_thread = sim.simulate(theta=theta, n_samples=10000, n_threads=1)
+multi_thread = sim.simulate(theta=theta, n_samples=10000, n_threads=8)
 ```
 
-### Tutorial
+Check your installation's parallel capabilities:
 
-Check the [basic tutorial](https://lnccbrown.github.io/ssm-simulators/basic_tutorial/basic_tutorial/) in our documentation.
+```python
+from cssm._openmp_status import print_status
 
-### Advanced: Dependency Management with uv
+print_status()
+```
 
-We use `uv` for fast and efficient dependency management. To get started:
+---
 
-1. Install `uv`:
+## Development
+
+This project uses `uv` for dependency management:
+
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
+uv sync --all-groups
 ```
 
-2. Install dependencies (including development):
-```bash
-uv sync --all-groups  # Installs all dependency groups
-```
-
-#### Building Cython Extensions from Source
-
-For development or to rebuild with different settings:
+Rebuild Cython extensions after source changes:
 
 ```bash
-# Clean environment and sync
-rm -rf .venv && uv sync
-
-# Rebuild Cython extensions (editable install)
 uv pip install --python .venv/bin/python -e . --reinstall
 ```
 
-**Important**: Always use `uv pip install --python .venv/bin/python` to ensure extensions
-are built for the correct Python version in your virtual environment.
+Run the main local checks:
 
-### Contributing
+```bash
+uv run pytest tests/
+uv run ruff check .
+uv run ruff format --check .
+uv run --extra docs mkdocs build
+```
 
-We welcome contributions from the community! Whether you want to add a new model, improve documentation, or fix bugs, your help is appreciated.
+---
 
-#### Contributing New Models
+## Contributing
 
-Want to add your own sequential sampling model to the package? Check out our comprehensive guide:
+Contributions are welcome, including new models, documentation improvements,
+bug fixes, and simulator validation work.
 
-**[📖 Contributing New Models Tutorial](https://lnccbrown.github.io/ssm-simulators/contributing/add_models/)**
+- Add a model: <https://lnccbrown.github.io/ssm-simulators/contributing/add_models/>
+- Add a parameter adapter: <https://lnccbrown.github.io/ssm-simulators/contributing/add_parameter_adapters/>
+- Open an issue: <https://github.com/lnccbrown/ssm-simulators/issues>
+- Open a pull request: <https://github.com/lnccbrown/ssm-simulators/pulls>
 
-This guide walks you through three levels of contribution:
-- **Level 1**: Add boundary/drift variants (~15 min)
-- **Level 2**: Implement Python simulators (~20 min)
-- **Level 3**: Create high-performance Cython implementations (~30 min)
+---
 
-#### Other Contributions
+## Citation
 
-For bug reports, feature requests, or general questions:
-- Open an issue on [GitHub Issues](https://github.com/lnccbrown/ssm-simulators/issues)
-- Check existing issues to avoid duplicates
-- Provide clear descriptions and reproducible examples
-
-### Cite `ssm-simulators`
-
-Please use the this DOI to cite ssm-simulators: [https://doi.org/10.5281/zenodo.17156205](https://doi.org/10.5281/zenodo.17156205)
+Please cite `ssm-simulators` with the Zenodo DOI:
+<https://doi.org/10.5281/zenodo.17156205>.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 ## SSMS (Sequential Sampling Model Simulators)
 
-[![DOI](https://zenodo.org/badge/370812185.svg)](https://doi.org/10.5281/zenodo.17156205)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.17156205-blue)](https://doi.org/10.5281/zenodo.17156205)
 ![PyPI](https://img.shields.io/pypi/v/ssm-simulators)
-![PyPI_dl](https://img.shields.io/pypi/dm/ssm-simulators)
+[![Downloads](https://static.pepy.tech/badge/ssm-simulators/month)](https://pepy.tech/projects/ssm-simulators)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/lnccbrown/ssm-simulators)](https://github.com/lnccbrown/ssm-simulators/pulls)
 [![Python Version](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/ssm-simulators/)
 [![Run tests](https://img.shields.io/github/actions/workflow/status/lnccbrown/ssm-simulators/run_tests.yml?branch=main&label=tests)](https://github.com/lnccbrown/ssm-simulators/actions/workflows/run_tests.yml)

--- a/docs/api/rlssm.md
+++ b/docs/api/rlssm.md
@@ -5,6 +5,20 @@ reinforcement-learning sequential sampling models (RLSSMs). Combine a learning
 process, SSM decision process, and task environment; simulate balanced panels
 compatible with HSSM inference.
 
+An RLSSM links two time scales:
+
+- within a trial, a decision process generates a response, and sometimes an RT;
+- across trials, a learning process updates latent states such as Q-values from
+  choices, feedback, rewards, or other task context.
+
+The same ssms-defined learning rule can therefore serve three workflows:
+
+1. synthetic data generation in `ssms.rl.Simulator`;
+2. RLSSM likelihood construction in HSSM through
+   `hssm.rl.RLSSMConfig.from_ssms_model(...)`;
+3. posterior predictive simulation by conditioning learning on observed trial
+   histories and resimulating responses with posterior parameter draws.
+
 ## Quick start
 
 ```python
@@ -30,6 +44,9 @@ data = sim.simulate(
 
 See the [RLSSM tutorial](../core_tutorials/rlssm_tutorial.ipynb)
 for presets, building a model, simulating participants, validation, and plots.
+For focused examples, see
+[RLSSM simulation and HSSM handoff](../core_tutorials/rlssm_simulation_hssm_handoff.ipynb)
+and [choice-only RL models](../core_tutorials/choice_only_rl_models.ipynb).
 
 ## Public API
 
@@ -42,8 +59,14 @@ for presets, building a model, simulating participants, validation, and plots.
 | `env` | Task environments (`Bandit`, `TaskConfig`, …) |
 | `learning` | Learning processes (`RescorlaWagnerDrift`, `RescorlaWagnerSoftmax`, …) |
 | `preset` | Preset registry (`get`, `list`, `info`, `register`) |
+| `validate_rlssm_data` | Standalone validation helper used by `ModelConfig.validate_data()` |
 
 Import style: `import ssms.rl as rl`.
+
+Most users should start from `rl.preset.get(...)` and `rl.Simulator(...)`. Use
+`ModelConfig` directly when you need a custom task environment, response mapping,
+or learning process. Use `assemble(backend="jax")` only when integrating with an
+inference package or inspecting the participant-wise computed-parameter contract.
 
 ## Model configuration
 
@@ -137,11 +160,11 @@ participant-wise theta length.
 
 - `mode="generative"` — the default unconstrained simulation loop. The simulator
   samples responses, task context, and learning updates end to end.
-- `mode="ppc"` — observed-history-conditioned resimulation for tutorials, smoke
-  tests, and manual checks. Learning state is conditioned on observed trial history;
-  RT/response are resimulated and observed context fields are copied into output.
-  This is **not** a replacement for PyMC/HSSM posterior predictive checks after
-  inference — use HSSM's inference workflow for canonical PPCs.
+- `mode="ppc"` — observed-history-conditioned posterior predictive simulation.
+  Learning state is conditioned on observed trial history; RT/response are
+  resimulated and observed context fields are copied into output. After HSSM
+  inference, posterior draws can be routed through the same simulator contract
+  to check whether inferred learning and decision parameters reproduce behavior.
 
 PPC mode uses the same data contract as inference validation (see below). The
 observed panel must include `participant_id`, all `config.response` columns
@@ -236,6 +259,24 @@ report = config.validate_data(data.drop(columns=["rt"]))
 report.raise_for_errors()
 ```
 
+Choice-only PPC uses the same response-only contract. Empirical `observed_data`
+must not contain an `rt` column for these presets, and PPC output omits `rt`:
+
+```python
+response_only = data.drop(columns=["rt"])
+ppc = rl.Simulator(config).simulate(
+    theta={"rl_alpha": 0.2, "beta": 2.0},
+    mode="ppc",
+    observed_data=response_only,
+    random_state=13,
+)
+```
+
+The lower-level `inv_temp_softmax_4` decision process is also available for
+four-choice softmax simulation. Built-in RL presets currently cover the two- and
+three-choice bandit cases; custom `ModelConfig` objects can pair
+`RescorlaWagnerSoftmax(n_actions=4)` with `decision_process="inv_temp_softmax_4"`.
+
 ### Context fields
 
 Outcome-like values are ordinary context fields. By default, built-in bandits emit a
@@ -305,6 +346,11 @@ with the JAX backend, checks gradient support, and wraps
 `AssembledModel.assemble_participant_fn(output="dict")` for HSSM's annotated
 computed-parameter contract.
 
+This bridge is what lets HSSM evaluate RLSSM likelihoods while keeping the
+learning rule, response-to-choice mapping, and task context source of truth in
+ssms. For choice-only RL models, pass response-only data to HSSM, not the
+generative simulator's placeholder `rt` column.
+
 **Note:** HSSM's bridge factory still calls the pre-refactor `compile()` API
 until the separate `hssm-rlssm-api` task updates it to `assemble()`.
 
@@ -331,6 +377,16 @@ planned separately in HSSM.
 ::: ssms.rl.simulator.Simulator
 
 ::: ssms.rl.assembled.resolve_model
+
+::: ssms.rl.preset.get
+
+::: ssms.rl.preset.list
+
+::: ssms.rl.preset.info
+
+::: ssms.rl.preset.register
+
+::: ssms.rl.validation.validate_rlssm_data
 
 ::: ssms.rl.learning.LearningProcess
 

--- a/docs/basic_tutorial/basic_tutorial.ipynb
+++ b/docs/basic_tutorial/basic_tutorial.ipynb
@@ -176,7 +176,7 @@
     "    model=\"ddm\",\n",
     "    theta={\"v\": 0, \"a\": 1, \"z\": 0.5, \"t\": 0.5},\n",
     "    n_samples=10000,\n",
-    "    n_threads=1, # If you install ssm-simulators via conda-forge or have gsl installed, you can set n_threads to the number of cores you have.\n",
+    "    n_threads=1, # If you have OpenMP and GSL installed, you can set n_threads to the number of cores you have.\n",
     ")"
    ]
   },

--- a/docs/core_tutorials/choice_only_rl_models.ipynb
+++ b/docs/core_tutorials/choice_only_rl_models.ipynb
@@ -1,0 +1,1134 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "db7c95d9",
+   "metadata": {},
+   "source": [
+    "# Choice-only RL Models\n",
+    "\n",
+    "Audience:\n",
+    "- Users modeling choices without response-time likelihoods.\n",
+    "- HSSM users preparing response-only RLSSM data from ssms simulations.\n",
+    "\n",
+    "Prerequisites:\n",
+    "- Basic familiarity with Rescorla-Wagner learning and softmax choice rules.\n",
+    "- `ssm-simulators` installed with compiled simulator extensions.\n",
+    "\n",
+    "By the end you will be able to:\n",
+    "- Simulate choice-only Rescorla-Wagner softmax models.\n",
+    "- Explain the `beta` inverse-temperature parameter.\n",
+    "- Validate response-only data for HSSM handoff.\n",
+    "- Use ssms PPC for choice-only posterior predictive simulation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9628287",
+   "metadata": {},
+   "source": [
+    "## Outline\n",
+    "\n",
+    "1. Load the built-in choice-only presets.\n",
+    "2. Simulate response-only RL data.\n",
+    "3. Inspect the Q-value learning rule.\n",
+    "4. Validate and prepare data for HSSM.\n",
+    "5. Run choice-only PPC and extend to more actions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "17e19f56",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:39.639671Z",
+     "iopub.status.busy": "2026-07-09T21:31:39.639576Z",
+     "iopub.status.idle": "2026-07-09T21:31:40.584051Z",
+     "shell.execute_reply": "2026-07-09T21:31:40.583627Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "import ssms.rl as rl\n",
+    "\n",
+    "pd.set_option(\"display.max_columns\", 20)\n",
+    "pd.set_option(\"display.width\", 120)\n",
+    "\n",
+    "SEED = 91"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b054a569",
+   "metadata": {},
+   "source": [
+    "## 1. What makes a choice-only RL model different?\n",
+    "\n",
+    "Classic RLSSMs often produce both RT and choice. Choice-only RL models keep the trial-wise learning rule but use a categorical softmax decision process instead of an RT likelihood.\n",
+    "\n",
+    "For the built-in inverse-temperature softmax models, the learner emits pre-update Q-values (`q0`, `q1`, ...), and the decision process samples choices from `softmax(beta * q_values)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "098a0aaa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:40.585523Z",
+     "iopub.status.busy": "2026-07-09T21:31:40.585406Z",
+     "iopub.status.idle": "2026-07-09T21:31:40.588114Z",
+     "shell.execute_reply": "2026-07-09T21:31:40.587693Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['2AB_RW_Angle', '2AB_RW_InvTempSoftmax', '3AB_RW_InvTempSoftmax']"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rl.preset.list()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3ec6559b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:40.589130Z",
+     "iopub.status.busy": "2026-07-09T21:31:40.589067Z",
+     "iopub.status.idle": "2026-07-09T21:31:40.591133Z",
+     "shell.execute_reply": "2026-07-09T21:31:40.590809Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Preset: 2AB_RW_InvTempSoftmax\n",
+      "Description: Two-armed bandit with a Rescorla-Wagner delta-rule learner and a choice-only inverse-temperature softmax decision process.\n",
+      "Task: two-armed Bernoulli bandit\n",
+      "Learning process: RescorlaWagnerSoftmax\n",
+      "Decision process: inv_temp_softmax_2\n",
+      "Required parameters: rl_alpha, beta\n",
+      "Default parameters: rl_alpha=0.2, beta=1\n",
+      "Response labels: (0, 1)\n",
+      "Response to choice: {0: 0, 1: 1}\n",
+      "Context fields: ['feedback']\n",
+      "Learning backend: jax\n",
+      "Gradient support: available\n",
+      "HSSM participant contract: yes\n"
+     ]
+    }
+   ],
+   "source": [
+    "config = rl.preset.get(\"2AB_RW_InvTempSoftmax\")\n",
+    "print(rl.preset.info(\"2AB_RW_InvTempSoftmax\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e31f6184",
+   "metadata": {},
+   "source": [
+    "## 2. Simulate a two-armed choice-only model\n",
+    "\n",
+    "The required parameters are just the learning rate `rl_alpha` and inverse temperature `beta`. Larger `beta` makes choices more deterministic for the currently higher-valued option."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3e303d52",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:40.592079Z",
+     "iopub.status.busy": "2026-07-09T21:31:40.592018Z",
+     "iopub.status.idle": "2026-07-09T21:31:41.174646Z",
+     "shell.execute_reply": "2026-07-09T21:31:41.174211Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(600, 5)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>participant_id</th>\n",
+       "      <th>trial_id</th>\n",
+       "      <th>rt</th>\n",
+       "      <th>response</th>\n",
+       "      <th>feedback</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>-1.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>-1.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>-1.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "      <td>-1.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>4</td>\n",
+       "      <td>-1.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   participant_id  trial_id   rt  response  feedback\n",
+       "0               0         0 -1.0         0       1.0\n",
+       "1               0         1 -1.0         0       1.0\n",
+       "2               0         2 -1.0         0       1.0\n",
+       "3               0         3 -1.0         1       1.0\n",
+       "4               0         4 -1.0         0       0.0"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "theta = {\"rl_alpha\": 0.20, \"beta\": 2.0}\n",
+    "\n",
+    "sim = rl.Simulator(config)\n",
+    "data = sim.simulate(\n",
+    "    theta=theta,\n",
+    "    n_trials=120,\n",
+    "    n_participants=5,\n",
+    "    random_state=SEED,\n",
+    ")\n",
+    "\n",
+    "print(data.shape)\n",
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "3b250008",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:41.175639Z",
+     "iopub.status.busy": "2026-07-09T21:31:41.175529Z",
+     "iopub.status.idle": "2026-07-09T21:31:41.181038Z",
+     "shell.execute_reply": "2026-07-09T21:31:41.180583Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Columns: ['participant_id', 'trial_id', 'rt', 'response', 'feedback']\n",
+      "Unique rt placeholders: [np.float64(-1.0)]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>n_trials</th>\n",
+       "      <th>p_choice_1</th>\n",
+       "      <th>mean_feedback</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>participant_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>120</td>\n",
+       "      <td>0.392</td>\n",
+       "      <td>0.558</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>120</td>\n",
+       "      <td>0.342</td>\n",
+       "      <td>0.550</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>120</td>\n",
+       "      <td>0.292</td>\n",
+       "      <td>0.600</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>120</td>\n",
+       "      <td>0.283</td>\n",
+       "      <td>0.592</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>120</td>\n",
+       "      <td>0.367</td>\n",
+       "      <td>0.600</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                n_trials  p_choice_1  mean_feedback\n",
+       "participant_id                                     \n",
+       "0                    120       0.392          0.558\n",
+       "1                    120       0.342          0.550\n",
+       "2                    120       0.292          0.600\n",
+       "3                    120       0.283          0.592\n",
+       "4                    120       0.367          0.600"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(\"Columns:\", data.columns.tolist())\n",
+    "print(\"Unique rt placeholders:\", sorted(data[\"rt\"].unique()))\n",
+    "\n",
+    "choice_summary = (\n",
+    "    data.groupby(\"participant_id\")\n",
+    "    .agg(\n",
+    "        n_trials=(\"trial_id\", \"count\"),\n",
+    "        p_choice_1=(\"response\", lambda x: (x == 1).mean()),\n",
+    "        mean_feedback=(\"feedback\", \"mean\"),\n",
+    "    )\n",
+    "    .round(3)\n",
+    ")\n",
+    "choice_summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d2a6be2",
+   "metadata": {},
+   "source": [
+    "The `rt` column is present only because the low-level simulator interface has historically returned RT arrays. For choice-only models, every value is the non-omission placeholder `-1.0`; it is not an observed response time."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7e5c164",
+   "metadata": {},
+   "source": [
+    "## 3. Inspect the learning rule\n",
+    "\n",
+    "`RescorlaWagnerSoftmax` emits Q-values before each update. After the observed response and feedback, the chosen action is updated by the Rescorla-Wagner delta rule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "057ca9ef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:41.182129Z",
+     "iopub.status.busy": "2026-07-09T21:31:41.182074Z",
+     "iopub.status.idle": "2026-07-09T21:31:41.186491Z",
+     "shell.execute_reply": "2026-07-09T21:31:41.186100Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>trial_id</th>\n",
+       "      <th>q0</th>\n",
+       "      <th>q1</th>\n",
+       "      <th>response</th>\n",
+       "      <th>feedback</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0.5000</td>\n",
+       "      <td>0.50000</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0.6000</td>\n",
+       "      <td>0.50000</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>0.6800</td>\n",
+       "      <td>0.50000</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0.7440</td>\n",
+       "      <td>0.50000</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>4</td>\n",
+       "      <td>0.7440</td>\n",
+       "      <td>0.60000</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>5</td>\n",
+       "      <td>0.5952</td>\n",
+       "      <td>0.60000</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>6</td>\n",
+       "      <td>0.5952</td>\n",
+       "      <td>0.48000</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>7</td>\n",
+       "      <td>0.5952</td>\n",
+       "      <td>0.58400</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>8</td>\n",
+       "      <td>0.5952</td>\n",
+       "      <td>0.46720</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>9</td>\n",
+       "      <td>0.5952</td>\n",
+       "      <td>0.57376</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   trial_id      q0       q1  response  feedback\n",
+       "0         0  0.5000  0.50000         0       1.0\n",
+       "1         1  0.6000  0.50000         0       1.0\n",
+       "2         2  0.6800  0.50000         0       1.0\n",
+       "3         3  0.7440  0.50000         1       1.0\n",
+       "4         4  0.7440  0.60000         0       0.0\n",
+       "5         5  0.5952  0.60000         1       0.0\n",
+       "6         6  0.5952  0.48000         1       1.0\n",
+       "7         7  0.5952  0.58400         1       0.0\n",
+       "8         8  0.5952  0.46720         1       1.0\n",
+       "9         9  0.5952  0.57376         0       0.0"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learner = rl.learning.RescorlaWagnerSoftmax(n_actions=2, initial_q=0.5)\n",
+    "state = learner.init_state()\n",
+    "rows = []\n",
+    "\n",
+    "first_subject = data[data[\"participant_id\"] == 0].head(10)\n",
+    "for _, trial in first_subject.iterrows():\n",
+    "    q_before = learner.compute_python(state, {\"rl_alpha\": theta[\"rl_alpha\"]}, {})\n",
+    "    rows.append(\n",
+    "        {\n",
+    "            \"trial_id\": int(trial[\"trial_id\"]),\n",
+    "            **q_before,\n",
+    "            \"response\": int(trial[\"response\"]),\n",
+    "            \"feedback\": float(trial[\"feedback\"]),\n",
+    "        }\n",
+    "    )\n",
+    "    state = learner.update_python(\n",
+    "        state,\n",
+    "        {\"rl_alpha\": theta[\"rl_alpha\"]},\n",
+    "        {\"choice\": int(trial[\"response\"]), \"feedback\": float(trial[\"feedback\"])},\n",
+    "    )\n",
+    "\n",
+    "pd.DataFrame(rows)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77052901",
+   "metadata": {},
+   "source": [
+    "## 4. Validate response-only data\n",
+    "\n",
+    "Drop the placeholder `rt` column before HSSM handoff or choice-only PPC. The model config declares `response=[\"response\"]`, so validation expects participant IDs, responses, and context fields such as `feedback`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "56d1207b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:41.187629Z",
+     "iopub.status.busy": "2026-07-09T21:31:41.187550Z",
+     "iopub.status.idle": "2026-07-09T21:31:41.191798Z",
+     "shell.execute_reply": "2026-07-09T21:31:41.191444Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RLSSM data validation report:\n",
+      "  [WARNING] extra_columns: data has extra columns not required by this model: ['trial_id'].\n",
+      "  panel shape: participants=5, trials_per_participant=120\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>participant_id</th>\n",
+       "      <th>trial_id</th>\n",
+       "      <th>response</th>\n",
+       "      <th>feedback</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>4</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   participant_id  trial_id  response  feedback\n",
+       "0               0         0         0       1.0\n",
+       "1               0         1         0       1.0\n",
+       "2               0         2         0       1.0\n",
+       "3               0         3         1       1.0\n",
+       "4               0         4         0       0.0"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response_only = data.drop(columns=[\"rt\"])\n",
+    "report = config.validate_data(response_only)\n",
+    "report.print()\n",
+    "report.raise_for_errors()\n",
+    "response_only.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "975609fe",
+   "metadata": {},
+   "source": [
+    "HSSM handoff uses response-only data:\n",
+    "\n",
+    "```python\n",
+    "import hssm\n",
+    "\n",
+    "hssm_config = hssm.rl.RLSSMConfig.from_ssms_model(\"2AB_RW_InvTempSoftmax\")\n",
+    "model = hssm.RLSSM(data=response_only, model_config=hssm_config)\n",
+    "```\n",
+    "\n",
+    "The ssms learning rule supplies the trial-wise Q-value trajectory used by the HSSM RLSSM likelihood."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "354734d6",
+   "metadata": {},
+   "source": [
+    "## 5. Choice-only posterior predictive simulation\n",
+    "\n",
+    "For choice-only PPC, `observed_data` must also be response-only. The simulator replays the observed response/feedback sequence to condition learning, then samples new responses from the softmax decision process."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "03d45181",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:41.192764Z",
+     "iopub.status.busy": "2026-07-09T21:31:41.192691Z",
+     "iopub.status.idle": "2026-07-09T21:31:41.410269Z",
+     "shell.execute_reply": "2026-07-09T21:31:41.409882Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PPC columns: ['participant_id', 'trial_id', 'response', 'feedback']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>observed_response</th>\n",
+       "      <th>ppc_response</th>\n",
+       "      <th>feedback_replayed</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    observed_response  ppc_response  feedback_replayed\n",
+       "0                   0             1                1.0\n",
+       "1                   0             0                1.0\n",
+       "2                   0             1                1.0\n",
+       "3                   1             0                1.0\n",
+       "4                   0             0                0.0\n",
+       "5                   1             0                0.0\n",
+       "6                   1             0                1.0\n",
+       "7                   1             1                0.0\n",
+       "8                   1             1                1.0\n",
+       "9                   0             0                0.0\n",
+       "10                  0             1                1.0\n",
+       "11                  1             0                0.0"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ppc = sim.simulate(\n",
+    "    theta=theta,\n",
+    "    mode=\"ppc\",\n",
+    "    observed_data=response_only,\n",
+    "    random_state=SEED + 1,\n",
+    ")\n",
+    "\n",
+    "print(\"PPC columns:\", ppc.columns.tolist())\n",
+    "\n",
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        \"observed_response\": response_only[\"response\"].head(12),\n",
+    "        \"ppc_response\": ppc[\"response\"].head(12),\n",
+    "        \"feedback_replayed\": ppc[\"feedback\"].head(12),\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ccf37b7",
+   "metadata": {},
+   "source": [
+    "## 6. Three- and four-choice variants\n",
+    "\n",
+    "ssms ships two- and three-armed choice-only RL presets. The lower-level `inv_temp_softmax_4` decision process is also available for custom four-choice configs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "aa9ad349",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:41.411363Z",
+     "iopub.status.busy": "2026-07-09T21:31:41.411293Z",
+     "iopub.status.idle": "2026-07-09T21:31:41.555462Z",
+     "shell.execute_reply": "2026-07-09T21:31:41.555014Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "response\n",
+       "0    0.530\n",
+       "1    0.248\n",
+       "2    0.222\n",
+       "Name: proportion, dtype: float64"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "config3 = rl.preset.get(\"3AB_RW_InvTempSoftmax\")\n",
+    "sim3 = rl.Simulator(config3)\n",
+    "data3 = sim3.simulate(\n",
+    "    theta=theta,\n",
+    "    n_trials=90,\n",
+    "    n_participants=3,\n",
+    "    random_state=SEED + 2,\n",
+    ")\n",
+    "\n",
+    "data3[\"response\"].value_counts(normalize=True).sort_index().round(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "a007f44c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:41.556542Z",
+     "iopub.status.busy": "2026-07-09T21:31:41.556478Z",
+     "iopub.status.idle": "2026-07-09T21:31:41.663822Z",
+     "shell.execute_reply": "2026-07-09T21:31:41.663361Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "response\n",
+       "0    0.394\n",
+       "1    0.206\n",
+       "2    0.169\n",
+       "3    0.231\n",
+       "Name: proportion, dtype: float64"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "config4 = rl.ModelConfig(\n",
+    "    model_name=\"4AB_RW_InvTempSoftmax_Demo\",\n",
+    "    description=\"Four-armed Rescorla-Wagner softmax demonstration model.\",\n",
+    "    decision_process=\"inv_temp_softmax_4\",\n",
+    "    learning_process=rl.learning.RescorlaWagnerSoftmax(n_actions=4, initial_q=0.5),\n",
+    "    task_environment=rl.env.Bandit.bernoulli(\n",
+    "        probabilities=[0.55, 0.25, 0.15, 0.05],\n",
+    "        response_labels=[0, 1, 2, 3],\n",
+    "    ),\n",
+    "    response=[\"response\"],\n",
+    ")\n",
+    "\n",
+    "sim4 = rl.Simulator(config4)\n",
+    "data4 = sim4.simulate(\n",
+    "    theta=theta,\n",
+    "    n_trials=80,\n",
+    "    n_participants=2,\n",
+    "    random_state=SEED + 3,\n",
+    ")\n",
+    "\n",
+    "data4[\"response\"].value_counts(normalize=True).sort_index().round(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29c6e3c3",
+   "metadata": {},
+   "source": [
+    "## Exercise\n",
+    "\n",
+    "Try changing `beta` while keeping `rl_alpha` fixed. Lower `beta` produces more exploratory choices; higher `beta` makes the model more likely to pick the currently best-valued option."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "d6eae598",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:41.664920Z",
+     "iopub.status.busy": "2026-07-09T21:31:41.664849Z",
+     "iopub.status.idle": "2026-07-09T21:31:42.082923Z",
+     "shell.execute_reply": "2026-07-09T21:31:42.082557Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>beta_0.5</th>\n",
+       "      <th>beta_6.0</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>response</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.532</td>\n",
+       "      <td>0.897</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.468</td>\n",
+       "      <td>0.103</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          beta_0.5  beta_6.0\n",
+       "response                    \n",
+       "0            0.532     0.897\n",
+       "1            0.468     0.103"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "low_beta = sim.simulate(\n",
+    "    theta={\"rl_alpha\": 0.20, \"beta\": 0.5},\n",
+    "    n_trials=120,\n",
+    "    n_participants=5,\n",
+    "    random_state=SEED,\n",
+    ")\n",
+    "high_beta = sim.simulate(\n",
+    "    theta={\"rl_alpha\": 0.20, \"beta\": 6.0},\n",
+    "    n_trials=120,\n",
+    "    n_participants=5,\n",
+    "    random_state=SEED,\n",
+    ")\n",
+    "\n",
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        \"beta_0.5\": low_beta[\"response\"].value_counts(normalize=True).sort_index(),\n",
+    "        \"beta_6.0\": high_beta[\"response\"].value_counts(normalize=True).sort_index(),\n",
+    "    }\n",
+    ").round(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5662e636",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "- Choice-only RL models keep trial-wise learning but omit the RT likelihood.\n",
+    "- `RescorlaWagnerSoftmax` emits Q-values, and `beta` controls softmax sensitivity.\n",
+    "- Generative choice-only output contains `rt=-1.0` only as a compatibility placeholder.\n",
+    "- HSSM handoff and ssms choice-only PPC should use response-only data."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/core_tutorials/rlssm_simulation_hssm_handoff.ipynb
+++ b/docs/core_tutorials/rlssm_simulation_hssm_handoff.ipynb
@@ -1,0 +1,903 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "693f8d95",
+   "metadata": {},
+   "source": [
+    "# RLSSM Simulation and HSSM Handoff\n",
+    "\n",
+    "Audience:\n",
+    "- Users who can already simulate a basic SSM and now want trial-wise learning models.\n",
+    "- HSSM users who want to understand what ssms contributes before inference.\n",
+    "\n",
+    "Prerequisites:\n",
+    "- `ssm-simulators` installed with compiled simulator extensions.\n",
+    "- Familiarity with response-time/choice data and basic reinforcement learning terms.\n",
+    "\n",
+    "By the end you will be able to:\n",
+    "- Explain the three moving parts of an RLSSM.\n",
+    "- Simulate synthetic RT + choice RLSSM data with a built-in preset.\n",
+    "- Validate the panel that will be passed to HSSM.\n",
+    "- Understand how the same ssms learning rule supports simulation, likelihood construction, and posterior predictive checks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0afb4840",
+   "metadata": {},
+   "source": [
+    "## Outline\n",
+    "\n",
+    "1. Load a built-in RLSSM preset.\n",
+    "2. Inspect the learning process, decision process, and task environment.\n",
+    "3. Generate a small synthetic panel.\n",
+    "4. Validate the data contract used by HSSM.\n",
+    "5. Run observed-history-conditioned posterior predictive simulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "18e685cf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:21.670026Z",
+     "iopub.status.busy": "2026-07-09T21:31:21.669834Z",
+     "iopub.status.idle": "2026-07-09T21:31:22.653376Z",
+     "shell.execute_reply": "2026-07-09T21:31:22.652847Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "import ssms.rl as rl\n",
+    "\n",
+    "pd.set_option(\"display.max_columns\", 20)\n",
+    "pd.set_option(\"display.width\", 120)\n",
+    "\n",
+    "SEED = 37"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9dee71ae",
+   "metadata": {},
+   "source": [
+    "## 1. What is an RLSSM?\n",
+    "\n",
+    "A reinforcement-learning sequential sampling model combines two loops.\n",
+    "\n",
+    "- Across trials, a learning rule updates latent state, such as Q-values, from choices and feedback.\n",
+    "- Within each trial, a decision process maps the current learned state to a response, and for RT + choice models, a response time.\n",
+    "\n",
+    "In ssms this is explicit: a `ModelConfig` combines a learning process, a task environment, and a decision process. HSSM can later consume the same structural config for inference through `RLSSMConfig.from_ssms_model(...)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "eb36b828",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:22.654887Z",
+     "iopub.status.busy": "2026-07-09T21:31:22.654771Z",
+     "iopub.status.idle": "2026-07-09T21:31:22.656890Z",
+     "shell.execute_reply": "2026-07-09T21:31:22.656513Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Preset: 2AB_RW_Angle\n",
+      "Description: Two-armed bandit with a Rescorla-Wagner delta-rule learner and an angle decision process.\n",
+      "Task: two-armed Bernoulli bandit\n",
+      "Learning process: RescorlaWagnerDrift\n",
+      "Decision process: angle\n",
+      "Required parameters: rl_alpha, scaler, a, z, t, theta\n",
+      "Default parameters: rl_alpha=0.2, scaler=2, a=1, z=0.5, t=0.001, theta=0\n",
+      "Response labels: (-1, 1)\n",
+      "Response to choice: {-1: 0, 1: 1}\n",
+      "Context fields: ['feedback']\n",
+      "Learning backend: jax\n",
+      "Gradient support: available\n",
+      "HSSM participant contract: yes\n"
+     ]
+    }
+   ],
+   "source": [
+    "config = rl.preset.get(\"2AB_RW_Angle\")\n",
+    "print(rl.preset.info(\"2AB_RW_Angle\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94799fda",
+   "metadata": {},
+   "source": [
+    "## 2. Inspect the model anatomy\n",
+    "\n",
+    "`2AB_RW_Angle` is a two-armed Bernoulli bandit. The Rescorla-Wagner learner computes trial-wise drift `v`; the `angle` decision process supplies the RT + choice likelihood family."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "728b976b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:22.657943Z",
+     "iopub.status.busy": "2026-07-09T21:31:22.657872Z",
+     "iopub.status.idle": "2026-07-09T21:31:22.666063Z",
+     "shell.execute_reply": "2026-07-09T21:31:22.665711Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>component</th>\n",
+       "      <th>value</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>model name</td>\n",
+       "      <td>2AB_RW_Angle</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>learning process</td>\n",
+       "      <td>RescorlaWagnerDrift</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>decision process</td>\n",
+       "      <td>angle</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>response columns</td>\n",
+       "      <td>[rt, response]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>response labels</td>\n",
+       "      <td>(-1, 1)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>context fields</td>\n",
+       "      <td>[feedback]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>required parameters</td>\n",
+       "      <td>[rl_alpha, scaler, a, z, t, theta]</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             component                               value\n",
+       "0           model name                        2AB_RW_Angle\n",
+       "1     learning process                 RescorlaWagnerDrift\n",
+       "2     decision process                               angle\n",
+       "3     response columns                      [rt, response]\n",
+       "4      response labels                             (-1, 1)\n",
+       "5       context fields                          [feedback]\n",
+       "6  required parameters  [rl_alpha, scaler, a, z, t, theta]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model_summary = pd.DataFrame(\n",
+    "    {\n",
+    "        \"component\": [\n",
+    "            \"model name\",\n",
+    "            \"learning process\",\n",
+    "            \"decision process\",\n",
+    "            \"response columns\",\n",
+    "            \"response labels\",\n",
+    "            \"context fields\",\n",
+    "            \"required parameters\",\n",
+    "        ],\n",
+    "        \"value\": [\n",
+    "            config.model_name,\n",
+    "            type(config.learning_process).__name__,\n",
+    "            config.decision_process,\n",
+    "            config.response,\n",
+    "            config.choices,\n",
+    "            config.context_fields,\n",
+    "            config.required_params,\n",
+    "        ],\n",
+    "    }\n",
+    ")\n",
+    "model_summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b141b558",
+   "metadata": {},
+   "source": [
+    "## 3. Simulate synthetic participants\n",
+    "\n",
+    "`theta` contains both learning parameters (`rl_alpha`, `scaler`) and fixed decision-process parameters (`a`, `z`, `t`, `theta`). The learning process computes drift `v` on every trial from the current Q-values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d18a38f6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:22.667010Z",
+     "iopub.status.busy": "2026-07-09T21:31:22.666951Z",
+     "iopub.status.idle": "2026-07-09T21:31:29.968094Z",
+     "shell.execute_reply": "2026-07-09T21:31:29.967648Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(320, 5)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>participant_id</th>\n",
+       "      <th>trial_id</th>\n",
+       "      <th>rt</th>\n",
+       "      <th>response</th>\n",
+       "      <th>feedback</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.314903</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.943819</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1.070650</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3.246168</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>4</td>\n",
+       "      <td>1.358311</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   participant_id  trial_id        rt  response  feedback\n",
+       "0               0         0  1.314903        -1       1.0\n",
+       "1               0         1  1.943819         1       0.0\n",
+       "2               0         2  1.070650        -1       1.0\n",
+       "3               0         3  3.246168         1       1.0\n",
+       "4               0         4  1.358311         1       1.0"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "theta = {\n",
+    "    \"rl_alpha\": 0.20,\n",
+    "    \"scaler\": 2.0,\n",
+    "    \"a\": 1.5,\n",
+    "    \"z\": 0.5,\n",
+    "    \"t\": 0.3,\n",
+    "    \"theta\": 0.2,\n",
+    "}\n",
+    "\n",
+    "sim = rl.Simulator(config)\n",
+    "data = sim.simulate(\n",
+    "    theta=theta,\n",
+    "    n_trials=80,\n",
+    "    n_participants=4,\n",
+    "    random_state=SEED,\n",
+    ")\n",
+    "\n",
+    "print(data.shape)\n",
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "29eb56b7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:29.969415Z",
+     "iopub.status.busy": "2026-07-09T21:31:29.969305Z",
+     "iopub.status.idle": "2026-07-09T21:31:29.975232Z",
+     "shell.execute_reply": "2026-07-09T21:31:29.974827Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>n_trials</th>\n",
+       "      <th>mean_rt</th>\n",
+       "      <th>p_upper_response</th>\n",
+       "      <th>mean_feedback</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>participant_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>80</td>\n",
+       "      <td>1.463</td>\n",
+       "      <td>0.175</td>\n",
+       "      <td>0.600</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>80</td>\n",
+       "      <td>1.469</td>\n",
+       "      <td>0.212</td>\n",
+       "      <td>0.612</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>80</td>\n",
+       "      <td>1.586</td>\n",
+       "      <td>0.262</td>\n",
+       "      <td>0.500</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>80</td>\n",
+       "      <td>1.773</td>\n",
+       "      <td>0.250</td>\n",
+       "      <td>0.625</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                n_trials  mean_rt  p_upper_response  mean_feedback\n",
+       "participant_id                                                    \n",
+       "0                     80    1.463             0.175          0.600\n",
+       "1                     80    1.469             0.212          0.612\n",
+       "2                     80    1.586             0.262          0.500\n",
+       "3                     80    1.773             0.250          0.625"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "summary = (\n",
+    "    data.groupby(\"participant_id\")\n",
+    "    .agg(\n",
+    "        n_trials=(\"trial_id\", \"count\"),\n",
+    "        mean_rt=(\"rt\", \"mean\"),\n",
+    "        p_upper_response=(\"response\", lambda x: (x == 1).mean()),\n",
+    "        mean_feedback=(\"feedback\", \"mean\"),\n",
+    "    )\n",
+    "    .round(3)\n",
+    ")\n",
+    "summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8cd0876f",
+   "metadata": {},
+   "source": [
+    "## 4. Validate before HSSM handoff\n",
+    "\n",
+    "The validator checks the columns and response labels required by the ssms/HSSM bridge: participant IDs, configured response columns, context fields, balanced trial panels, and valid response-to-choice mappings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b865d996",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:29.976270Z",
+     "iopub.status.busy": "2026-07-09T21:31:29.976202Z",
+     "iopub.status.idle": "2026-07-09T21:31:29.978939Z",
+     "shell.execute_reply": "2026-07-09T21:31:29.978523Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RLSSM data validation report:\n",
+      "  [WARNING] extra_columns: data has extra columns not required by this model: ['trial_id'].\n",
+      "  panel shape: participants=4, trials_per_participant=80\n"
+     ]
+    }
+   ],
+   "source": [
+    "report = config.validate_data(data)\n",
+    "report.print()\n",
+    "report.raise_for_errors()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0399ec9c",
+   "metadata": {},
+   "source": [
+    "## 5. HSSM consumes the ssms model contract\n",
+    "\n",
+    "HSSM should not duplicate the learning rule. The intended handoff is to pass the ssms model into HSSM's bridge factory:\n",
+    "\n",
+    "```python\n",
+    "import hssm\n",
+    "\n",
+    "hssm_config = hssm.rl.RLSSMConfig.from_ssms_model(config)  # or \"2AB_RW_Angle\"\n",
+    "model = hssm.RLSSM(data=data, model_config=hssm_config)\n",
+    "idata = model.sample()\n",
+    "```\n",
+    "\n",
+    "The bridge assembles the ssms learning rule into participant-wise computed parameters used by the HSSM likelihood. This is how the same ssms implementation supports synthetic data generation and RLSSM likelihoods for inference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf0af4f7",
+   "metadata": {},
+   "source": [
+    "## 6. Posterior predictive simulation\n",
+    "\n",
+    "`mode=\"ppc\"` conditions the learning state on an observed trial history, then resimulates responses and RTs. In an inference workflow, the `theta` values here would come from posterior draws rather than the known generative values used in this small example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "39b74bac",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:29.980084Z",
+     "iopub.status.busy": "2026-07-09T21:31:29.980015Z",
+     "iopub.status.idle": "2026-07-09T21:31:30.161399Z",
+     "shell.execute_reply": "2026-07-09T21:31:30.160954Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>participant_id</th>\n",
+       "      <th>trial_id</th>\n",
+       "      <th>observed_response</th>\n",
+       "      <th>ppc_response</th>\n",
+       "      <th>observed_rt</th>\n",
+       "      <th>ppc_rt</th>\n",
+       "      <th>feedback_replayed</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1.315</td>\n",
+       "      <td>3.367</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.944</td>\n",
+       "      <td>0.752</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.071</td>\n",
+       "      <td>1.398</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>3.246</td>\n",
+       "      <td>4.523</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>4</td>\n",
+       "      <td>1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1.358</td>\n",
+       "      <td>2.670</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>0</td>\n",
+       "      <td>5</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1.196</td>\n",
+       "      <td>0.787</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>0</td>\n",
+       "      <td>6</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.471</td>\n",
+       "      <td>0.957</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>0</td>\n",
+       "      <td>7</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.114</td>\n",
+       "      <td>0.904</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>0</td>\n",
+       "      <td>8</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2.407</td>\n",
+       "      <td>1.599</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>0</td>\n",
+       "      <td>9</td>\n",
+       "      <td>1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1.619</td>\n",
+       "      <td>1.208</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   participant_id  trial_id  observed_response  ppc_response  observed_rt  ppc_rt  feedback_replayed\n",
+       "0               0         0                 -1            -1        1.315   3.367                1.0\n",
+       "1               0         1                  1             1        1.944   0.752                0.0\n",
+       "2               0         2                 -1             1        1.071   1.398                1.0\n",
+       "3               0         3                  1            -1        3.246   4.523                1.0\n",
+       "4               0         4                  1            -1        1.358   2.670                1.0\n",
+       "5               0         5                 -1            -1        1.196   0.787                0.0\n",
+       "6               0         6                  1             1        1.471   0.957                0.0\n",
+       "7               0         7                 -1             1        1.114   0.904                1.0\n",
+       "8               0         8                  1             1        2.407   1.599                0.0\n",
+       "9               0         9                  1            -1        1.619   1.208                0.0"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ppc = sim.simulate(\n",
+    "    theta=theta,\n",
+    "    mode=\"ppc\",\n",
+    "    observed_data=data,\n",
+    "    random_state=SEED + 1,\n",
+    ")\n",
+    "\n",
+    "comparison = pd.DataFrame(\n",
+    "    {\n",
+    "        \"participant_id\": data[\"participant_id\"].head(10),\n",
+    "        \"trial_id\": data[\"trial_id\"].head(10),\n",
+    "        \"observed_response\": data[\"response\"].head(10),\n",
+    "        \"ppc_response\": ppc[\"response\"].head(10),\n",
+    "        \"observed_rt\": data[\"rt\"].head(10).round(3),\n",
+    "        \"ppc_rt\": ppc[\"rt\"].head(10).round(3),\n",
+    "        \"feedback_replayed\": ppc[\"feedback\"].head(10),\n",
+    "    }\n",
+    ")\n",
+    "comparison"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cd660d4",
+   "metadata": {},
+   "source": [
+    "## Exercise\n",
+    "\n",
+    "Change only `rl_alpha` and compare the simulated learning curves. Higher values adapt faster to recent feedback; lower values preserve prior Q-values longer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d662d597",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T21:31:30.162542Z",
+     "iopub.status.busy": "2026-07-09T21:31:30.162481Z",
+     "iopub.status.idle": "2026-07-09T21:31:30.338389Z",
+     "shell.execute_reply": "2026-07-09T21:31:30.337935Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>baseline_feedback</th>\n",
+       "      <th>fast_learning_feedback</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>trial_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>75</th>\n",
+       "      <td>0.525</td>\n",
+       "      <td>0.525</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>76</th>\n",
+       "      <td>0.500</td>\n",
+       "      <td>0.500</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>77</th>\n",
+       "      <td>0.475</td>\n",
+       "      <td>0.450</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>78</th>\n",
+       "      <td>0.425</td>\n",
+       "      <td>0.400</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>79</th>\n",
+       "      <td>0.425</td>\n",
+       "      <td>0.400</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          baseline_feedback  fast_learning_feedback\n",
+       "trial_id                                           \n",
+       "75                    0.525                   0.525\n",
+       "76                    0.500                   0.500\n",
+       "77                    0.475                   0.450\n",
+       "78                    0.425                   0.400\n",
+       "79                    0.425                   0.400"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fast_theta = {**theta, \"rl_alpha\": 0.55}\n",
+    "fast_data = sim.simulate(\n",
+    "    theta=fast_theta,\n",
+    "    n_trials=80,\n",
+    "    n_participants=4,\n",
+    "    random_state=SEED,\n",
+    ")\n",
+    "\n",
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        \"baseline_feedback\": data.groupby(\"trial_id\")[\"feedback\"].mean(),\n",
+    "        \"fast_learning_feedback\": fast_data.groupby(\"trial_id\")[\"feedback\"].mean(),\n",
+    "    }\n",
+    ").rolling(10, min_periods=1).mean().tail()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8339f82f",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "- An RLSSM is a learning process plus a task environment plus a decision process.\n",
+    "- ssms simulates the trial-wise learning loop and validates the data contract.\n",
+    "- HSSM consumes the ssms model contract for inference through `RLSSMConfig.from_ssms_model(...)`.\n",
+    "- Posterior predictive checks reuse the same learning logic while conditioning on observed histories."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,17 +18,67 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![codecov](https://codecov.io/gh/lnccbrown/ssm-simulators/branch/main/graph/badge.svg)](https://codecov.io/gh/lnccbrown/ssm-simulators)
 
-Python Package to collect simulators for Sequential Sampling Models.
+`ssm-simulators` provides fast C/Cython simulators for sequential sampling
+models used in cognitive science, neuroscience, and amortized Bayesian
+inference, spanning classic DDM variants, multi-choice models, attention
+models, and reinforcement-learning SSMs.
 
 Find the package documentation [here](https://lnccbrown.github.io/ssm-simulators/).
 
 
+### What can I simulate?
+
+Use `ssm-simulators` when you need to:
+
+- Simulate response-time and choice data from a broad library of sequential
+  sampling models.
+- Generate training data for likelihood approximation networks and other
+  amortized-inference workflows.
+- Prototype new SSM variants with custom drift functions, boundary functions,
+  parameter transforms, and high-performance Cython extensions.
+- Work with reinforcement-learning SSMs, including Rescorla-Wagner learning
+  rules and choice-only inverse-temperature softmax models.
+
+Model families include:
+
+- **Diffusion models**: DDM, full DDM, deadline variants, flexible-boundary DDMs
+  with angle and Weibull boundaries, Levy models, Ornstein-Uhlenbeck models,
+  gamma-drift models, conflict models, tradeoff models, and shrink-spotlight
+  variants.
+- **Multi-choice accumulators**: race models, racing diffusion models, LBA
+  models including two-, three-, and four-choice variants, LCA models, and
+  Poisson race models.
+- **Attention and fixation-conditioned models**: aDDM simulators with observed
+  or self-sampled fixation inputs, continuation strategies, and optional
+  trajectory metadata for visualization.
+- **Reinforcement-learning SSMs**: ssms-defined RL task presets, learning rules,
+  participant replay functions, RT+choice models, and choice-only softmax
+  decision processes.
+
+### Where it fits
+
+`ssm-simulators` is the simulator and data-generation layer of the HSSM
+ecosystem. It is used by [LANfactory](https://github.com/lnccbrown/LANfactory)
+and [LAN_pipeline_minimal](https://github.com/lnccbrown/LAN_pipeline_minimal)
+to generate training data for likelihood networks, and by
+[HSSM](https://github.com/lnccbrown/HSSM) to bridge simulator-defined model
+configurations into Bayesian inference workflows.
+
 ### Quick Start
 
-The `ssms` package serves two purposes.
+The `Simulator` class is the recommended user-facing API for direct simulation:
 
-1. Easy access to *fast simulators of sequential sampling models*
-2. Support infrastructure to construct training data for various approaches to likelihood / posterior amortization
+```python
+from ssms.basic_simulators import Simulator
+
+sim = Simulator("ddm")
+out = sim.simulate(
+    theta={"v": 1.0, "a": 1.5, "z": 0.5, "t": 0.2},
+    n_samples=1000,
+)
+
+print(out["rts"].shape, out["choices"].shape)
+```
 
 A number of tutorial notebooks are available under the `/notebooks` directory.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -129,13 +129,7 @@ Install the optional JAX backend for differentiable RLSSM learning processes:
 pip install "ssm-simulators[jax]"
 ```
 
-For full parallel support, conda-forge is recommended:
-
-```sh
-conda install -c conda-forge ssm-simulators
-```
-
-Pip users who need multi-threaded simulation should install OpenMP and GSL first:
+Users who need multi-threaded simulation should install OpenMP and GSL first:
 
 ```bash
 # macOS

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@
 
 ## SSMS (Sequential Sampling Model Simulators)
 
-[![DOI](https://zenodo.org/badge/370812185.svg)](https://doi.org/10.5281/zenodo.17156205)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.17156205-blue)](https://doi.org/10.5281/zenodo.17156205)
 ![PyPI](https://img.shields.io/pypi/v/ssm-simulators)
-![PyPI_dl](https://img.shields.io/pypi/dm/ssm-simulators)
+[![Downloads](https://static.pepy.tech/badge/ssm-simulators/month)](https://pepy.tech/projects/ssm-simulators)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/lnccbrown/ssm-simulators)](https://github.com/lnccbrown/ssm-simulators/pulls)
 [![Python Version](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/ssm-simulators/)
 [![Run tests](https://img.shields.io/github/actions/workflow/status/lnccbrown/ssm-simulators/run_tests.yml?branch=main&label=tests)](https://github.com/lnccbrown/ssm-simulators/actions/workflows/run_tests.yml)

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,7 +136,7 @@ Users who need multi-threaded simulation should install OpenMP and GSL first:
 brew install libomp gsl
 
 # Ubuntu/Debian
-sudo apt-get install libgomp-dev libgsl-dev
+sudo apt-get install build-essential libgsl-dev
 ```
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@
 ![PyPI](https://img.shields.io/pypi/v/ssm-simulators)
 ![PyPI_dl](https://img.shields.io/pypi/dm/ssm-simulators)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/lnccbrown/ssm-simulators)](https://github.com/lnccbrown/ssm-simulators/pulls)
-![Python Version](https://img.shields.io/pypi/pyversions/ssm-simulators)
+[![Python Version](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/ssm-simulators/)
 [![Run tests](https://img.shields.io/github/actions/workflow/status/lnccbrown/ssm-simulators/run_tests.yml?branch=main&label=tests)](https://github.com/lnccbrown/ssm-simulators/actions/workflows/run_tests.yml)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,7 @@
     <img src="images/mainlogo.png" style="width: 175px;">
 </div>
 
-
-## SSMS (Sequential Sampling Model Simulators)
+# SSMS: Sequential Sampling Model Simulators
 
 [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.17156205-blue)](https://doi.org/10.5281/zenodo.17156205)
 ![PyPI](https://img.shields.io/pypi/v/ssm-simulators)
@@ -23,50 +22,64 @@ models used in cognitive science, neuroscience, and amortized Bayesian
 inference, spanning classic DDM variants, multi-choice models, attention
 models, and reinforcement-learning SSMs.
 
-Find the package documentation [here](https://lnccbrown.github.io/ssm-simulators/).
+---
 
+## What ssms Provides
 
-### What can I simulate?
+| Area | Documentation path |
+| --- | --- |
+| Direct SSM simulation | [Basic tutorial](basic_tutorial/basic_tutorial.ipynb), [basic simulator API](api/basic_simulators.md) |
+| Model configuration | [Configuration systems](core_tutorials/tutorial_configs.ipynb), [config API](api/config.md) |
+| Training data generation | [Data generators](core_tutorials/tutorial_data_generators.ipynb), [dataset generator API](api/dataset_generators.md) |
+| RLSSM simulation | [RLSSM tutorial](core_tutorials/rlssm_tutorial.ipynb), [RLSSM API](api/rlssm.md) |
+| Choice-only RL models | [Choice-only RL tutorial](core_tutorials/choice_only_rl_models.ipynb), [RLSSM API](api/rlssm.md#choice-only-inverse-temperature-softmax-presets) |
+| New model contributions | [Contribute new models](contributing/add_models.md), [parameter adapters](contributing/add_parameter_adapters.md) |
 
-Use `ssm-simulators` when you need to:
+---
 
-- Simulate response-time and choice data from a broad library of sequential
-  sampling models.
-- Generate training data for likelihood approximation networks and other
-  amortized-inference workflows.
-- Prototype new SSM variants with custom drift functions, boundary functions,
-  parameter transforms, and high-performance Cython extensions.
-- Work with reinforcement-learning SSMs, including Rescorla-Wagner learning
-  rules and choice-only inverse-temperature softmax models.
+## Model Families
 
-Model families include:
+ssms covers a broad simulator surface:
 
-- **Diffusion models**: DDM, full DDM, deadline variants, flexible-boundary DDMs
-  with angle and Weibull boundaries, Levy models, Ornstein-Uhlenbeck models,
-  gamma-drift models, conflict models, tradeoff models, and shrink-spotlight
-  variants.
-- **Multi-choice accumulators**: race models, racing diffusion models, LBA
-  models including two-, three-, and four-choice variants, LCA models, and
+- **Diffusion models**: DDM, full DDM, deadline variants, angle and Weibull
+  boundaries, Levy, Ornstein-Uhlenbeck, gamma-drift, conflict, tradeoff, and
+  shrink-spotlight variants.
+- **Multi-choice accumulators**: race, racing diffusion, LBA, LBA4, LCA, and
   Poisson race models.
 - **Attention and fixation-conditioned models**: aDDM simulators with observed
   or self-sampled fixation inputs, continuation strategies, and optional
-  trajectory metadata for visualization.
-- **Reinforcement-learning SSMs**: ssms-defined RL task presets, learning rules,
-  participant replay functions, RT+choice models, and choice-only softmax
-  decision processes.
+  trajectory metadata.
+- **Reinforcement-learning SSMs**: Rescorla-Wagner learning rules, RT + choice
+  models, inverse-temperature softmax choice-only models, and posterior
+  predictive functions for response-only RL workflows.
 
-### Where it fits
+!!! note "Choice-only RL support"
+    ssms includes inverse-temperature softmax decision processes for two-,
+    three-, and four-choice settings. Built-in RL presets currently include
+    `2AB_RW_InvTempSoftmax` and `3AB_RW_InvTempSoftmax`.
+
+---
+
+## Ecosystem Fit
 
 `ssm-simulators` is the simulator and data-generation layer of the HSSM
-ecosystem. It is used by [LANfactory](https://github.com/lnccbrown/LANfactory)
-and [LAN_pipeline_minimal](https://github.com/lnccbrown/LAN_pipeline_minimal)
-to generate training data for likelihood networks, and by
-[HSSM](https://github.com/lnccbrown/HSSM) to bridge simulator-defined model
-configurations into Bayesian inference workflows.
+ecosystem.
 
-### Quick Start
+| Package | Role |
+| --- | --- |
+| [HSSM](https://github.com/lnccbrown/HSSM) | Consumes simulator-defined model contracts for Bayesian inference, including ssms-defined RLSSMs. |
+| [LANfactory](https://github.com/lnccbrown/LANfactory) | Trains likelihood approximation networks from ssms-generated data. |
+| [LAN_pipeline_minimal](https://github.com/lnccbrown/LAN_pipeline_minimal) | Runs data-generation and LAN-training pipelines. |
 
-The `Simulator` class is the recommended user-facing API for direct simulation:
+For RLSSMs, ssms owns the learning rule, task environment, response mapping,
+simulation loop, and posterior predictive behavior. HSSM consumes the assembled
+ssms model through `hssm.rl.RLSSMConfig.from_ssms_model(...)`.
+
+---
+
+## Quick Start
+
+### Classic SSM
 
 ```python
 from ssms.basic_simulators import Simulator
@@ -80,228 +93,65 @@ out = sim.simulate(
 print(out["rts"].shape, out["choices"].shape)
 ```
 
-A number of tutorial notebooks are available under the `/notebooks` directory.
+### RLSSM
 
-#### Installation
+```python
+import ssms.rl as rl
+
+config = rl.preset.get("2AB_RW_InvTempSoftmax")
+sim = rl.Simulator(config)
+
+data = sim.simulate(
+    theta={"rl_alpha": 0.2, "beta": 2.0},
+    n_trials=200,
+    n_participants=20,
+    random_state=42,
+)
+
+response_only = data.drop(columns=["rt"])
+config.validate_data(response_only).raise_for_errors()
+```
+
+Choice-only simulations emit `rt=-1.0` only as a compatibility placeholder in
+generative output. Use response-only data for HSSM handoff and choice-only PPC.
+
+---
+
+## Installation
 
 ```sh
 pip install ssm-simulators
 ```
 
-**Recommended: Install via conda-forge for full parallel support:**
+Install the optional JAX backend for differentiable RLSSM learning processes:
+
+```sh
+pip install "ssm-simulators[jax]"
+```
+
+For full parallel support, conda-forge is recommended:
 
 ```sh
 conda install -c conda-forge ssm-simulators
 ```
 
-> [!NOTE]
-> **Parallel Execution Requirements:**
->
-> For multi-threaded simulation (`n_threads > 1`), the package requires:
-> - **OpenMP**: For parallel loop execution
-> - **GSL (GNU Scientific Library)**: For validated random number generation
->
-> **conda-forge users**: Both dependencies are automatically included.
->
-> **pip users**: Install system dependencies first:
-> ```bash
-> # macOS
-> brew install libomp gsl
->
-> # Ubuntu/Debian
-> sudo apt-get install libgomp-dev libgsl-dev
-> ```
-> Then reinstall: `pip install --force-reinstall ssm-simulators`
->
-> Without these dependencies, the package works in single-threaded mode using NumPy.
-
-> [!NOTE]
-> Building from source or developing this package requires a C compiler (such as GCC).
-> On Linux, you can install GCC with:
-> ```bash
-> sudo apt-get install build-essential
-> ```
-> Most users installing from PyPI wheels do **not** need to install GCC.
-
-#### Parallel Execution Details
-
-When using `n_threads > 1`, the package uses GSL's validated Ziggurat algorithm for
-Gaussian random number generation, ensuring statistically correct simulations.
-
-**Thread Limit**: The maximum supported number of threads is **256** (compile-time limit).
-Requesting more threads will raise a `ValueError`. This limit exists because per-thread
-random number generator states are allocated as static arrays for performance.
-
-```python
-from ssms.basic_simulators import simulator
-
-# Single-threaded (uses NumPy RNG)
-result = simulator.simulator(model='ddm', theta=theta, n_samples=10000, n_threads=1)
-
-# Multi-threaded (uses GSL Ziggurat RNG, requires OpenMP + GSL)
-result = simulator.simulator(model='ddm', theta=theta, n_samples=10000, n_threads=8)
-```
-
-Check your installation's parallel capabilities:
-```python
-from cssm._openmp_status import print_status
-print_status()
-```
-
-#### Command Line Interface
-The package exposes a command-line tool, `generate`, for creating training data from a YAML configuration file.
+Pip users who need multi-threaded simulation should install OpenMP and GSL first:
 
 ```bash
-generate --config-path <path/to/config.yaml> --output <output/directory> [--log-level INFO]
+# macOS
+brew install libomp gsl
+
+# Ubuntu/Debian
+sudo apt-get install libgomp-dev libgsl-dev
 ```
 
-- `--config-path`: Path to your YAML configuration file (optional, uses default if not provided).
-- `--output`: Directory where generated data will be saved (required).
-- `--n-files`: (Optional) Number of data files to generate. Default is `1` file.
-- `--estimator-type`: (Optional) Likelihood estimator type (`kde` or `pyddm`). Overrides YAML config if specified.
-- `--log-level`: (Optional) Set the logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). Default is `WARNING`.
+---
 
-Below is a sample YAML configuration you can use with the `generate` command:
+## Next Steps
 
-```yaml
-MODEL: 'ddm'
-GENERATOR_APPROACH: 'lan'
-
-PIPELINE:
-  N_PARAMETER_SETS: 100
-  N_SUBRUNS: 20
-
-SIMULATOR:
-  N_SAMPLES: 2000
-  DELTA_T: 0.001
-
-TRAINING:
-  N_SAMPLES_PER_PARAM: 200
-
-ESTIMATOR:
-  TYPE: 'kde'  # Options: 'kde' (default) or 'pyddm'
-```
-
-Configuration file parameter details follow.
-
-**Top-Level Parameters:**
-| Option | Definition |
-| ------ | ---------- |
-| `MODEL` | The type of model you want to simulate (e.g., `ddm`, `angle`, `levy`) |
-| `GENERATOR_APPROACH` | Type of generator used to generate data (`lan` or `cpn`) |
-
-**PIPELINE Section:**
-| Option | Definition |
-| ------ | ---------- |
-| `N_PARAMETER_SETS` | Number of parameter vectors that are used for training |
-| `N_SUBRUNS` | Number of repetitions of each call to generate data |
-
-**SIMULATOR Section:**
-| Option | Definition |
-| ------ | ---------- |
-| `N_SAMPLES` | Number of samples a simulation run should entail for a given parameter set |
-| `DELTA_T` | Time discretization step used in numerical simulation of the model. Interval between updates of evidence-accumulation. |
-
-**TRAINING Section:**
-| Option | Definition |
-| ------ | ---------- |
-| `N_SAMPLES_PER_PARAM` | Number of times the kernel density estimate (KDE) is evaluated after creating the KDE from simulations of each set of model parameters |
-
-**ESTIMATOR Section:**
-| Option | Definition |
-| ------ | ---------- |
-| `TYPE` | Likelihood estimator type: `kde` (default) or `pyddm` |
-
-To make your own configuration file, you can copy the example above into a new `.yaml` file and modify it with your preferences.
-
-If you are using `uv` (see below), you can use the `uv run` command to run `generate` from the command line
-
-This will generate training data according to your configuration and save it in the specified output directory.
-
-### Key Features
-
-#### Custom Parameter Transforms
-
-Register custom transformations to apply model-specific modifications to sampled parameters:
-
-```python
-from ssms import register_transform_function
-import numpy as np
-
-# Register a custom transform
-def exponential_drift(theta: dict) -> dict:
-    if 'v' in theta:
-        theta['v'] = np.exp(theta['v'])
-    return theta
-
-register_transform_function("exp_v", exponential_drift)
-
-# Use in model configuration
-model_config = {
-    "name": "my_model",
-    "params": ["v", "a", "z", "t"],
-    "param_bounds": [...],
-    "parameter_transforms": [
-        {"type": "exp_v"}  # Your custom transform
-    ]
-}
-```
-
-### Tutorial
-
-Check the [basic tutorial](https://lnccbrown.github.io/ssm-simulators/basic_tutorial/basic_tutorial/) in our documentation.
-
-### Advanced: Dependency Management with uv
-
-We use `uv` for fast and efficient dependency management. To get started:
-
-1. Install `uv`:
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-2. Install dependencies (including development):
-```bash
-uv sync --all-groups  # Installs all dependency groups
-```
-
-#### Building Cython Extensions from Source
-
-For development or to rebuild with different settings:
-
-```bash
-# Clean environment and sync
-rm -rf .venv && uv sync
-
-# Rebuild Cython extensions (editable install)
-uv pip install --python .venv/bin/python -e . --reinstall
-```
-
-**Important**: Always use `uv pip install --python .venv/bin/python` to ensure extensions
-are built for the correct Python version in your virtual environment.
-
-### Contributing
-
-We welcome contributions from the community! Whether you want to add a new model, improve documentation, or fix bugs, your help is appreciated.
-
-#### Contributing New Models
-
-Want to add your own sequential sampling model to the package? Check out our comprehensive guide:
-
-**[📖 Contributing New Models Tutorial](https://lnccbrown.github.io/ssm-simulators/contributing/add_models/)**
-
-This guide walks you through three levels of contribution:
-- **Level 1**: Add boundary/drift variants (~15 min)
-- **Level 2**: Implement Python simulators (~20 min)
-- **Level 3**: Create high-performance Cython implementations (~30 min)
-
-#### Other Contributions
-
-For bug reports, feature requests, or general questions:
-- Open an issue on [GitHub Issues](https://github.com/lnccbrown/ssm-simulators/issues)
-- Check existing issues to avoid duplicates
-- Provide clear descriptions and reproducible examples
-
-### Cite `ssm-simulators`
-
-Please use the this DOI to cite ssm-simulators: [https://doi.org/10.5281/zenodo.17156205](https://doi.org/10.5281/zenodo.17156205)
+- Learn the basic simulator API in the [basic tutorial](basic_tutorial/basic_tutorial.ipynb).
+- Explore model families in the [package overview](core_tutorials/tutorial_capabilities.ipynb).
+- Generate LAN training data with the [data generator tutorial](core_tutorials/tutorial_data_generators.ipynb).
+- Build and simulate RLSSMs with the [RLSSM tutorial](core_tutorials/rlssm_tutorial.ipynb).
+- Learn response-only RL simulation in the [choice-only RL tutorial](core_tutorials/choice_only_rl_models.ipynb).
+- Use the [API reference](api/ssms.md) when integrating ssms into another package.

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,7 +8,7 @@
     Navigate the site here!
 </span>
 <span class="right-margin">
-    <a href="https://github.com/lnccbrown/ssm-simulators/releases/latest">v0.12.3 is out!</a>
+    <a href="https://github.com/lnccbrown/ssm-simulators/releases/latest">v0.13.0 is out!</a>
 </span>
 <span>
     <span class="twemoji">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,8 @@ nav:
       - Custom Models: core_tutorials/tutorial_custom_models.ipynb
       - Data Generators: core_tutorials/tutorial_data_generators.ipynb
       - RLSSM Tutorial: core_tutorials/rlssm_tutorial.ipynb
+      - RLSSM Simulation and HSSM Handoff: core_tutorials/rlssm_simulation_hssm_handoff.ipynb
+      - Choice-only RL Models: core_tutorials/choice_only_rl_models.ipynb
       - RLSSM Tutorial (Advanced): core_tutorials/rlssm_advanced_tutorial.ipynb
       - KDE Class: core_tutorials/kde_class.ipynb
       - PyDDM Integration: core_tutorials/tutorial_simulators_vs_pyddm.ipynb
@@ -35,9 +37,7 @@ plugins:
   - search
   - autorefs
   - mkdocs-jupyter:
-      execute: True
-      # execute_ignore:
-      #   - basic_tutorial/basic_tutorial.ipynb
+      execute: False
   - mkdocstrings:
       default_handler: python
       handlers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ssm-simulators"
-version = "0.12.5"
+version = "0.13.0"
 description = "SSMS is a package collecting simulators and training data generators for cognitive science, neuroscience, and approximate bayesian computation"
 authors = [
     { name = "Alexander Fengler", email = "alexander_fengler@brown.edu" },
 ]
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">3.10,<3.15"
+requires-python = ">=3.12,<3.15"
 dependencies = [
     "scipy >= 1.6.3",
     "pandas >= 1.0.0",
@@ -28,7 +28,8 @@ dependencies = [
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
@@ -204,7 +205,7 @@ ignore = [
 ]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,6 @@ def gsl_available():
         print("  Install GSL for parallel RNG support:")
         print("    macOS:  brew install gsl")
         print("    Ubuntu: apt install libgsl-dev")
-        print("    Conda:  conda install -c conda-forge gsl")
 
     return _GSL_AVAILABLE
 

--- a/src/cssm/_openmp_status.pyx
+++ b/src/cssm/_openmp_status.pyx
@@ -219,8 +219,7 @@ def check_parallel_request(n_threads, warn=True):
                 f"Running with n_threads=1.\n"
                 f"To enable parallel support:\n"
                 f"  - macOS: brew install libomp && pip install --force-reinstall ssm-simulators\n"
-                f"  - Linux: Ensure OpenMP dev packages are installed (libgomp-dev)\n"
-                f"  - Conda: conda install -c conda-forge ssm-simulators",
+                f"  - Linux: Ensure OpenMP dev packages are installed (libgomp-dev)",
                 RuntimeWarning,
                 stacklevel=3
             )
@@ -236,8 +235,7 @@ def check_parallel_request(n_threads, warn=True):
                 f"GSL is required for correct parallel random number generation.\n"
                 f"To enable parallel support:\n"
                 f"  - macOS: brew install gsl && pip install --force-reinstall ssm-simulators\n"
-                f"  - Linux: apt install libgsl-dev && pip install --force-reinstall ssm-simulators\n"
-                f"  - Conda: conda install -c conda-forge ssm-simulators (recommended)",
+                f"  - Linux: apt install libgsl-dev && pip install --force-reinstall ssm-simulators",
                 RuntimeWarning,
                 stacklevel=3
             )
@@ -273,9 +271,7 @@ def print_status():
             print("  GSL:")
             print("    macOS:  brew install gsl")
             print("    Linux:  apt install libgsl-dev")
-            print("    Conda:  conda install -c conda-forge gsl")
         print("\n  Then reinstall: pip install --force-reinstall ssm-simulators")
-        print("  Or use conda:   conda install -c conda-forge ssm-simulators")
 
 
 # Run status check if executed directly

--- a/src/cssm/_openmp_status.pyx
+++ b/src/cssm/_openmp_status.pyx
@@ -219,7 +219,7 @@ def check_parallel_request(n_threads, warn=True):
                 f"Running with n_threads=1.\n"
                 f"To enable parallel support:\n"
                 f"  - macOS: brew install libomp && pip install --force-reinstall ssm-simulators\n"
-                f"  - Linux: Ensure OpenMP dev packages are installed (libgomp-dev)",
+                f"  - Linux: apt install build-essential && pip install --force-reinstall ssm-simulators",
                 RuntimeWarning,
                 stacklevel=3
             )
@@ -266,7 +266,7 @@ def print_status():
         if not info['openmp_available']:
             print("  OpenMP:")
             print("    macOS:  brew install libomp")
-            print("    Linux:  apt install libgomp-dev (or equivalent)")
+            print("    Linux:  apt install build-essential")
         if not info['gsl_available']:
             print("  GSL:")
             print("    macOS:  brew install gsl")

--- a/tests/rl/test_hssm_bridge_contract.py
+++ b/tests/rl/test_hssm_bridge_contract.py
@@ -1,7 +1,5 @@
 """Tests for the public ssms.rl surfaces consumed by HSSM."""
 
-from pathlib import Path
-
 import numpy as np
 import pytest
 
@@ -84,43 +82,3 @@ def test_simulated_preset_data_validates_for_hssm_handoff():
     assert report.n_participants == 2
     assert report.n_trials == 12
     report.raise_for_errors()
-
-
-def test_rlssm_docs_name_active_hssm_bridge_factory():
-    docs = Path("docs/api/rlssm.md").read_text()
-
-    assert "RLSSMConfig.from_ssms_model" in docs
-    assert "hssm.RLSSM(data=data, model_config=hssm_config)" in docs
-    assert "structural inspection" in docs
-
-
-def test_rlssm_docs_cover_choice_only_ppc_and_validation_surface():
-    docs = Path("docs/api/rlssm.md").read_text()
-
-    assert "posterior predictive simulation" in docs
-    assert "2AB_RW_InvTempSoftmax" in docs
-    assert "3AB_RW_InvTempSoftmax" in docs
-    assert "inv_temp_softmax_4" in docs
-    assert "validate_rlssm_data" in docs
-    assert "response-only data" in docs
-
-
-def test_rlssm_tutorials_are_listed_without_docs_execution():
-    mkdocs = Path("mkdocs.yml").read_text()
-
-    assert "core_tutorials/rlssm_simulation_hssm_handoff.ipynb" in mkdocs
-    assert "core_tutorials/choice_only_rl_models.ipynb" in mkdocs
-    assert "execute: False" in mkdocs
-
-
-def test_new_rlssm_tutorials_name_handoff_and_choice_only_contracts():
-    handoff = Path(
-        "docs/core_tutorials/rlssm_simulation_hssm_handoff.ipynb"
-    ).read_text()
-    choice_only = Path("docs/core_tutorials/choice_only_rl_models.ipynb").read_text()
-
-    assert "RLSSMConfig.from_ssms_model" in handoff
-    assert "posterior predictive" in handoff
-    assert "rt=-1.0" in choice_only
-    assert "response-only data" in choice_only
-    assert 'mode=\\"ppc\\"' in choice_only

--- a/tests/rl/test_hssm_bridge_contract.py
+++ b/tests/rl/test_hssm_bridge_contract.py
@@ -92,3 +92,33 @@ def test_rlssm_docs_name_active_hssm_bridge_factory():
     assert "RLSSMConfig.from_ssms_model" in docs
     assert "hssm.RLSSM(data=data, model_config=hssm_config)" in docs
     assert "structural inspection" in docs
+
+
+def test_rlssm_docs_cover_choice_only_ppc_and_validation_surface():
+    docs = Path("docs/api/rlssm.md").read_text()
+
+    assert "posterior predictive simulation" in docs
+    assert "2AB_RW_InvTempSoftmax" in docs
+    assert "3AB_RW_InvTempSoftmax" in docs
+    assert "inv_temp_softmax_4" in docs
+    assert "validate_rlssm_data" in docs
+    assert "response-only data" in docs
+
+
+def test_rlssm_tutorials_are_listed_without_docs_execution():
+    mkdocs = Path("mkdocs.yml").read_text()
+
+    assert "core_tutorials/rlssm_simulation_hssm_handoff.ipynb" in mkdocs
+    assert "core_tutorials/choice_only_rl_models.ipynb" in mkdocs
+    assert "execute: False" in mkdocs
+
+
+def test_new_rlssm_tutorials_name_handoff_and_choice_only_contracts():
+    handoff = Path("docs/core_tutorials/rlssm_simulation_hssm_handoff.ipynb").read_text()
+    choice_only = Path("docs/core_tutorials/choice_only_rl_models.ipynb").read_text()
+
+    assert "RLSSMConfig.from_ssms_model" in handoff
+    assert "posterior predictive" in handoff
+    assert "rt=-1.0" in choice_only
+    assert "response-only data" in choice_only
+    assert "mode=\\\"ppc\\\"" in choice_only

--- a/tests/rl/test_hssm_bridge_contract.py
+++ b/tests/rl/test_hssm_bridge_contract.py
@@ -114,11 +114,13 @@ def test_rlssm_tutorials_are_listed_without_docs_execution():
 
 
 def test_new_rlssm_tutorials_name_handoff_and_choice_only_contracts():
-    handoff = Path("docs/core_tutorials/rlssm_simulation_hssm_handoff.ipynb").read_text()
+    handoff = Path(
+        "docs/core_tutorials/rlssm_simulation_hssm_handoff.ipynb"
+    ).read_text()
     choice_only = Path("docs/core_tutorials/choice_only_rl_models.ipynb").read_text()
 
     assert "RLSSMConfig.from_ssms_model" in handoff
     assert "posterior predictive" in handoff
     assert "rt=-1.0" in choice_only
     assert "response-only data" in choice_only
-    assert "mode=\\\"ppc\\\"" in choice_only
+    assert 'mode=\\"ppc\\"' in choice_only


### PR DESCRIPTION
## Summary

Prepare `ssm-simulators` for the `0.13.0` release.

This aligns the package with the upcoming HSSM release by dropping Python 3.11
support and declaring/building for Python 3.12-3.14.

## Changes

- Bump package version to `0.13.0`.
- Set `requires-python = ">=3.12,<3.15"`.
- Update Python classifiers to Python 3 only, 3.12, 3.13, and 3.14.
- Update mypy target to Python 3.12.
- Remove Python 3.11 from the GitHub Actions test matrix.
- Remove `cp311` from cibuildwheel targets.
- Replace the broken Zenodo DOI badge image with a stable Shields DOI badge.
- Replace the problematic PyPI downloads badge with a Pepy monthly-downloads
  badge.
- Update README/docs Python support badges to Python 3.12-3.14.
- Refresh README/docs landing-page overview with a clearer package description,
  model-family summary, `Simulator` example, and links to HSSM, LANfactory, and
  LAN_pipeline_minimal.
- Further reorganize the README and docs overview with clearer sectioning,
  coverage tables, tutorial links, installation guidance, classic-SSM and RLSSM
  quick starts, and posterior-predictive wording for RL workflows.
- Expand `docs/api/rlssm.md` with RLSSM concepts, synthetic-data generation,
  HSSM likelihood handoff, response-only choice models, posterior predictive
  simulation, `inv_temp_softmax_4`, preset helpers, and validation helpers.
- Add executed tutorial notebooks:
  `docs/core_tutorials/rlssm_simulation_hssm_handoff.ipynb` and
  `docs/core_tutorials/choice_only_rl_models.ipynb`.
- Add both tutorials to MkDocs nav and set `mkdocs-jupyter.execute: False` so
  ssms docs builds do not execute notebooks.
- Add docs-contract assertions for the new RLSSM API/tutorial coverage.
- Update the docs announcement banner to `v0.13.0 is out!`.

## Validation

- `git diff --check`
- `uv run pytest tests/rl/test_hssm_bridge_contract.py --no-cov -q`
- `uv run pytest tests/rl/test_choice_only_inv_temp_softmax.py --no-cov -q`
- `uv run ruff check tests/rl/test_hssm_bridge_contract.py`
- `MPLCONFIGDIR=/tmp/.mpl uv run --extra docs mkdocs build`
- Executed both new tutorial notebooks with `jupyter nbconvert --execute
  --inplace`.
- Checked both new notebooks with `dev-notebook-inspect ... check
  --require-executed`.
- Parsed `pyproject.toml` with `tomllib` and confirmed:
  - version `0.13.0`
  - `requires-python = ">=3.12,<3.15"`
  - Python classifiers
  - mypy target `3.12`

## Release Notes

Curated release notes draft:
`_local/choice-only-rl-ssms/release-notes-v0.13.0.md`

Highlights to include when publishing the GitHub release:

- aDDM simulator and efpt engine provenance/license
- plain four-choice LBA configuration
- choice-only inverse-temperature softmax RL presets
- public RW learning class refactor
- response-only validation and PPC behavior
- HSSM bridge notes
- Python 3.12-3.14 support window

## Notes

- Python 3.11 support is intentionally dropped in this release.
- Publishing the GitHub release will trigger TestPyPI/PyPI upload through the
  existing release workflow, so merge first, verify CI, then publish the release
  deliberately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tutorials for choice-only reinforcement-learning models and RLSSM-to-HSSM workflows.
  - Expanded guidance for simulation, validation, posterior predictive checks, parallel execution, and training-data generation.

- **Documentation**
  - Refreshed the README and documentation homepage with clearer model coverage, quick starts, installation notes, and ecosystem guidance.
  - Updated RLSSM API documentation and release announcements.

- **Compatibility**
  - Version 0.13.0 now supports Python 3.12–3.14.

- **Bug Fixes**
  - Clarified runtime guidance when OpenMP or GSL is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->