### PR TITLE
Build portable manylinux wheels (fix -march=native SIGILL); release 0.13.1

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,7 +8,7 @@
     Navigate the site here!
 </span>
 <span class="right-margin">
-    <a href="https://github.com/lnccbrown/ssm-simulators/releases/latest">v0.13.0 is out!</a>
+    <a href="https://github.com/lnccbrown/ssm-simulators/releases/latest">v0.13.1 is out!</a>
 </span>
 <span>
     <span class="twemoji">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ssm-simulators"
-version = "0.13.0"
+version = "0.13.1"
 description = "SSMS is a package collecting simulators and training data generators for cognitive science, neuroscience, and approximate bayesian computation"
 authors = [
     { name = "Alexander Fengler", email = "alexander_fengler@brown.edu" },

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ GSL support is OPTIONAL (but required for correct parallel RNG):
 """
 
 import os
+import platform
 import subprocess
 import sys
 import tempfile
@@ -251,11 +252,23 @@ def get_openmp_flags(with_openmp=True):
     Returns:
         dict with keys: extra_compile_args, extra_link_args, include_dirs, define_macros
     """
+    # -march for the distributed Linux wheels must be portable. Use x86-64-v2
+    # (SSE4.2 baseline, universal on x86-64 since ~2011) on x86; omit -march on
+    # aarch64/other so the compiler's portable default (armv8-a) applies. NEVER
+    # -march=native: it bakes the *build* host's ISA (AVX2/AVX-512) into the wheel
+    # and SIGILLs on narrower runner CPUs downstream. x86-64-v3 (AVX2) would also
+    # SIGILL on SSE4.2-only cloud CPUs, so v2 is the right floor. x86-64-v2 is an
+    # x86-only -march value, so it must be gated off aarch64 (GCC rejects it there).
+    linux_march = (
+        ["-march=x86-64-v2"]
+        if platform.machine().lower() in ("x86_64", "amd64")
+        else []
+    )
     # Base optimization flags (always applied)
     base_flags = {
-        "darwin": ["-O3", "-ffast-math"],  # Skip -march=native for portability on macOS
+        "darwin": ["-O3", "-ffast-math"],  # Skip -march for portability on macOS
         "win32": ["/O2"],
-        "linux": ["-O3", "-flto", "-ffast-math", "-march=native", "-funroll-loops"],
+        "linux": ["-O3", "-flto", "-ffast-math", *linux_march, "-funroll-loops"],
     }
 
     platform_key = "linux" if sys.platform not in ("darwin", "win32") else sys.platform
@@ -309,7 +322,7 @@ def get_openmp_flags(with_openmp=True):
                 "-O3",
                 "-flto",
                 "-ffast-math",
-                "-march=native",
+                *linux_march,  # x86-only portable baseline; see base_flags
                 "-funroll-loops",
             ],
             "extra_link_args": ["-fopenmp", "-flto"],


### PR DESCRIPTION
## Problem — the ecosystem's intermittent `exit 132` CI crash

The released Linux wheels compile the Cython extensions with **`-march=native`** (`setup.py`, both the base and OpenMP flag paths). cibuildwheel builds those wheels on a GitHub runner and `-march=native` bakes **that build host's CPU ISA** (AVX2/AVX-512) into the `cssm/*.so`. A wheel tagged `manylinux…x86_64` is supposed to run on any x86-64 CPU, but this one carries build-host-specific instructions.

Installed on a **different** runner whose CPU lacks those instructions, `import ssms` executes an illegal instruction → **SIGILL / exit 132**, *before any test runs* (no Python traceback). It's intermittent purely because it depends on the roulette of test-runner CPU vs. build-runner CPU.

**Who is exposed:** consumers that install the **PyPI wheel** — **LANfactory** and **HSSM** (no `[tool.uv.sources]` override). Consumers that source-build ssm-sim on their own runner (**LAN_pipeline_minimal** via git main; ssm-sim's own `run_tests`) have build-host == run-host, so `-march=native` is safe there and they were never exposed.

macOS already skips `-march` "for portability" — the same reasoning just never reached the Linux path, which is the one that ships shared wheels.

## Fix — arch-gated portable `-march`

- **x86-64** → `-march=x86-64-v2` (SSE4.2 baseline, universal on x86-64 since ~2011): keeps portable vectorization, runs on **every** x86-64 runner. (`v3`/AVX2 would reintroduce SIGILL on SSE4.2-only cloud CPUs — `v2` is the safe floor.)
- **aarch64 / other** → **omit `-march`** (the compiler's default `armv8-a` target is already portable). `x86-64-v2` is an x86-only value that aarch64 GCC rejects, so the flag is gated on `platform.machine()`.

Performance is unaffected in practice: the simulator hot loops are scalar Euler–Maruyama first-passage recurrences (loop-carried dependency + data-dependent trip count + branchy GSL RNG) that don't autovectorize at any SIMD width — throughput scales with OpenMP threads, not `-march` level.

## Version propagation (release 0.13.1)

- `pyproject.toml`: `0.13.0` → `0.13.1` (0.13.0 is already on PyPI, so this ships as a patch).
- `docs/overrides/main.html`: banner `v0.13.0` → `v0.13.1`.
- `__version__` single-sources from package metadata (`ssms/` + `src/cssm/__init__.py`), so it follows the bump automatically.

## Verification

Both CI workflows run on this PR:
- **`build_wheels.yml`** — cibuildwheel builds the manylinux wheels (x86-64 **and aarch64**) with the arch-gated `-march`.
- **`run_tests.yml`** — compiles `ssms` from source on ubuntu (x86) + the OpenMP/GSL multithreading job.

## After merge — downstream propagation (separate PRs, in order)

Tag `v0.13.1` → cibuildwheel publishes the portable wheels. Then:

- **LANfactory**: `ssm-simulators>=0.12.2` → `>=0.13.1` — this is what makes LANfactory CI green **and** lets the SIGILL retry wrapper in `run_tests.yml` come out.
- **HSSM**: `ssm-simulators>=0.12.4` → `>=0.13.1`.
- **LAN_pipeline_minimal**: **no action** — it already pulls ssm-sim from git `main` via `[tool.uv.sources]`, so it gets the fix automatically on merge.
- **hssm-feedstock**: bump via the `update-feedstock` skill after the PyPI release.
- **HSSMSpine**: refresh the version-pin matrix in `_context/CONTEXT.md` (currently lists HSSM as `>=0.12.2`, actual is `>=0.12.4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)