### PR TITLE
Prepare ssm-simulators 0.13.2 release

### DIFF
--- a/docs/basic_tutorial/basic_tutorial.ipynb
+++ b/docs/basic_tutorial/basic_tutorial.ipynb
@@ -2,574 +2,479 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "2b354785",
    "metadata": {},
    "source": [
-    "### Quick Start"
+    "# Basic Tutorial: Simulate and Inspect Sequential Sampling Models\n",
+    "\n",
+    "This tutorial introduces the main `ssm-simulators` workflow: create a\n",
+    "simulator, generate reaction times and choices, inspect the result, and\n",
+    "build a small training-data example.\n",
+    "\n",
+    "The notebook runs locally after installing `ssm-simulators` and can also\n",
+    "be opened in [Google Colab](https://colab.research.google.com/github/lnccbrown/ssm-simulators/blob/main/docs/basic_tutorial/basic_tutorial.ipynb)."
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "cf7036d0",
    "metadata": {},
    "source": [
-    "[![Open with marimo](https://marimo.io/shield.svg)](https://molab.marimo.io/github/lnccbrown/ssm-simulators/blob/main/docs/basic_tutorial/basic_tutorial.ipynb)\n",
-    "[![Open with colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lnccbrown/ssm-simulators/blob/main/docs/basic_tutorial/basic_tutorial.ipynb)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The `ssms` package serves two purposes. \n",
+    "## Install\n",
     "\n",
-    "1. Easy access to *fast simulators of sequential sampling models*\n",
-    "   \n",
-    "2. Support infrastructure to construct training data for various approaches to likelihood / posterior amortization\n",
+    "For a local environment, install the package from PyPI before starting\n",
+    "Jupyter:\n",
     "\n",
-    "We provide two minimal examples here to illustrate how to use each of the two capabilities."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Install \n",
+    "```bash\n",
+    "python -m pip install ssm-simulators\n",
+    "```\n",
     "\n",
-    "Let's start with *installing* the `ssms` package.\n",
-    "\n",
-    "You can do so by typing,\n",
-    "\n",
-    "`pip install ssm-simulators`\n",
-    "\n",
-    "in your terminal.\n",
-    "\n",
-    "Below you find a basic tutorial on how to use the package."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Notebook Setup"
+    "The next cell installs the package only when the notebook is running in\n",
+    "Colab. It is skipped in a local Jupyter session where the package is\n",
+    "already installed."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-12T01:46:35.121010Z",
-     "iopub.status.busy": "2026-07-12T01:46:35.120925Z",
-     "iopub.status.idle": "2026-07-12T01:46:35.124406Z",
-     "shell.execute_reply": "2026-07-12T01:46:35.123929Z"
-    }
-   },
+   "id": "2f930aea",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
     "\n",
-    "if (\"COLAB_RELEASE_TAG\" in os.environ):\n",
-    "    !pip install ssm-simulators\n",
-    "    pass # helps keep code running in molab\n",
-    "elif any([\"MARIMO\" in item_ \\\n",
-    "            for item_ in os.environ]):\n",
-    "    import marimo as mo\n",
-    "    mo.dependencies(pip=[\"ssm-simulators\", \"pandas\"])"
+    "if \"COLAB_RELEASE_TAG\" in os.environ:\n",
+    "    %pip install -q ssm-simulators"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "8551617c",
    "metadata": {},
    "source": [
-    "#### Tutorial"
+    "## Imports\n",
+    "\n",
+    "`ssm-simulators` provides fast simulators for sequential sampling models.\n",
+    "We will use NumPy for checks, pandas for a compact tabular view, and\n",
+    "Matplotlib for one basic diagnostic plot."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-12T01:46:35.125796Z",
-     "iopub.status.busy": "2026-07-12T01:46:35.125721Z",
-     "iopub.status.idle": "2026-07-12T01:46:35.816509Z",
-     "shell.execute_reply": "2026-07-12T01:46:35.816078Z"
-    }
-   },
+   "id": "ed874953",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# Import necessary packages\n",
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "import ssms"
+    "import ssms\n",
+    "\n",
+    "from ssms import Simulator"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "796efdcc",
    "metadata": {},
    "source": [
-    "#### Using the Simulators\n",
+    "## Create a Simulator\n",
     "\n",
-    "Let's start with using the basic simulators. \n",
-    "You access the main simulators through the  `ssms.basic_simulators.simulator.simulator()` function.\n",
-    "\n",
-    "To get an idea about the models included in `ssms`, use the `config` module.\n",
-    "The central dictionary with metadata about included models sits in `ssms.config.model_config`. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Check included models\n",
-    "list(ssms.config.model_config.keys())[:10]\n"
+    "The class-based interface is the recommended starting point. Pass a\n",
+    "model name to `Simulator` and inspect the stable parts of its\n",
+    "configuration before simulating data."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-12T01:46:35.817779Z",
-     "iopub.status.busy": "2026-07-12T01:46:35.817683Z",
-     "iopub.status.idle": "2026-07-12T01:46:35.820202Z",
-     "shell.execute_reply": "2026-07-12T01:46:35.819900Z"
-    }
-   },
+   "id": "16aaa0d9",
+   "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "{'name': 'ddm',\n",
-       " 'params': ['v', 'a', 'z', 't'],\n",
-       " 'param_bounds': [[-3.0, 0.3, 0.1, 0.0], [3.0, 2.5, 0.9, 2.0]],\n",
-       " 'boundary_name': 'constant',\n",
-       " 'boundary': <function ssms.basic_simulators.boundary_functions.constant(t: float | numpy.ndarray = 0, a: float = 1.0) -> float | numpy.ndarray>,\n",
-       " 'boundary_params': [],\n",
-       " 'n_params': 4,\n",
-       " 'default_params': [0.0, 1.0, 0.5, 0.001],\n",
-       " 'nchoices': 2,\n",
-       " 'choices': [-1, 1],\n",
-       " 'n_particles': 1,\n",
-       " 'simulator': <cyfunction ddm_flexbound at 0x120fdf040>,\n",
-       " 'parameter_transforms': {'sampling': [], 'simulation': []},\n",
-       " 'param_bounds_dict': {'v': (-3.0, 3.0),\n",
-       "  'a': (0.3, 2.5),\n",
-       "  'z': (0.1, 0.9),\n",
-       "  't': (0.0, 2.0)}}"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: ddm\n",
+      "Parameters: ['v', 'a', 'z', 't']\n",
+      "Choices: 2\n"
+     ]
     }
    ],
    "source": [
-    "# Take an example config for a given model\n",
-    "ssms.config.model_config[\"ddm\"]"
+    "ddm_sim = Simulator(\"ddm\")\n",
+    "\n",
+    "print(\"Model:\", ddm_sim.config[\"name\"])\n",
+    "print(\"Parameters:\", ddm_sim.config[\"params\"])\n",
+    "print(\"Choices:\", ddm_sim.config[\"nchoices\"])"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "93c9a23c",
    "metadata": {},
    "source": [
-    "**Note:**\n",
-    "The usual structure of these models includes,\n",
+    "## Simulate Reaction Times and Choices\n",
     "\n",
-    "- Parameter names (`'params'`)\n",
-    "- Bounds on the parameters (`'param_bounds'`)\n",
-    "- A function that defines a boundary for the respective model (`'boundary'`)\n",
-    "- The number of parameters (`'n_params'`)\n",
-    "- Defaults for the parameters (`'default_params'`)\n",
-    "- The number of choices the process can produce (`'nchoices'`)"
+    "A parameter dictionary supplies one value for each model parameter. The\n",
+    "result is a dictionary containing arrays such as `rts` and `choices`.\n",
+    "`random_state` makes the example reproducible across notebook runs."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-12T01:46:35.835101Z",
-     "iopub.status.busy": "2026-07-12T01:46:35.835020Z",
-     "iopub.status.idle": "2026-07-12T01:46:35.884980Z",
-     "shell.execute_reply": "2026-07-12T01:46:35.884598Z"
+   "id": "c851d080",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output keys: ['choices', 'metadata', 'rts']\n",
+      "RT shape: (1000, 1)\n",
+      "Choice shape: (1000, 1)\n"
+     ]
     }
-   },
-   "outputs": [],
+   ],
    "source": [
-    "from ssms.basic_simulators.simulator import simulator\n",
+    "theta = {\"v\": 0.0, \"a\": 1.0, \"z\": 0.5, \"t\": 0.5}\n",
+    "sim_out = ddm_sim.simulate(theta=theta, n_samples=1000, random_state=42)\n",
     "\n",
-    "sim_out = simulator(\n",
-    "    model=\"ddm\",\n",
-    "    theta={\"v\": 0, \"a\": 1, \"z\": 0.5, \"t\": 0.5},\n",
-    "    n_samples=10000,\n",
-    "    n_threads=1, # If you have OpenMP and GSL installed, you can set n_threads to the number of cores you have.\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The output of the simulator is a `dictionary` with three elements.\n",
+    "rts = sim_out[\"rts\"].ravel()\n",
+    "choices = sim_out[\"choices\"].ravel()\n",
     "\n",
-    "1. `rts` (array)\n",
-    "2. `choices` (array)\n",
-    "3. `metadata` (dictionary)\n",
-    "\n",
-    "The `metadata` includes the named parameters, simulator settings, and more.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Using the Class-Based Simulator Interface\n",
-    "\n",
-    "In addition to the functional `simulator()` approach shown above, `ssms` provides a modern **class-based interface** via the `Simulator` class. This approach offers several advantages:\n",
-    "\n",
-    "- **Reusable configuration**: Create a simulator once, run many simulations\n",
-    "- **Extensibility**: Easily customize boundary functions, drift functions, or even provide your own simulator\n",
-    "- **Cleaner API**: Object-oriented design with explicit configuration\n"
+    "print(\"Output keys:\", sorted(sim_out))\n",
+    "print(\"RT shape:\", sim_out[\"rts\"].shape)\n",
+    "print(\"Choice shape:\", sim_out[\"choices\"].shape)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-12T01:46:35.886351Z",
-     "iopub.status.busy": "2026-07-12T01:46:35.886284Z",
-     "iopub.status.idle": "2026-07-12T01:46:35.893165Z",
-     "shell.execute_reply": "2026-07-12T01:46:35.892821Z"
-    }
-   },
+   "id": "487834a1",
+   "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Keys: dict_keys(['rts', 'choices', 'metadata'])\n",
-      "RT shape: (1000, 1)\n",
-      "Choices shape: (1000, 1)\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>rt</th>\n",
+       "      <th>choice</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1.254133</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1.214967</td>\n",
+       "      <td>-1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1.950749</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1.389157</td>\n",
+       "      <td>-1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1.270219</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         rt  choice\n",
+       "0  1.254133       1\n",
+       "1  1.214967      -1\n",
+       "2  1.950749       1\n",
+       "3  1.389157      -1\n",
+       "4  1.270219       1"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Import the Simulator class (also available as ssms.Simulator)\n",
-    "from ssms import Simulator\n",
-    "\n",
-    "# Create a simulator for the DDM model\n",
-    "ddm_sim = Simulator(\"ddm\")\n",
-    "\n",
-    "# Run a simulation with named parameters\n",
-    "sim_out_class = ddm_sim.simulate(\n",
-    "    theta={\"v\": 0, \"a\": 1, \"z\": 0.5, \"t\": 0.5}, \n",
-    "    n_samples=1000,\n",
-    ")\n",
-    "\n",
-    "# The output format is identical to the functional approach\n",
-    "print(\"Keys:\", sim_out_class.keys())\n",
-    "print(\"RT shape:\", sim_out_class[\"rts\"].shape)\n",
-    "print(\"Choices shape:\", sim_out_class[\"choices\"].shape)"
+    "simulated_data = pd.DataFrame({\"rt\": rts, \"choice\": choices})\n",
+    "simulated_data.head()"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "ec02de69",
    "metadata": {},
    "source": [
-    "The `Simulator` lass stores the model configuration, which you can inspect:\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Access the model configuration\n",
-    "print(\"Model name:\", ddm_sim.config[\"name\"])\n",
-    "print(\"Parameters:\", ddm_sim.config[\"params\"])\n",
-    "print(\"Number of choices:\", ddm_sim.config[\"nchoices\"])\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Reproducibility**: Use `random_state` to get reproducible simulations:"
+    "### Reproducibility\n",
+    "\n",
+    "Passing the same seed to the same simulator produces the same arrays.\n",
+    "This is useful for examples, tests, and debugging."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-12T01:46:35.894195Z",
-     "iopub.status.busy": "2026-07-12T01:46:35.894146Z",
-     "iopub.status.idle": "2026-07-12T01:46:35.897272Z",
-     "shell.execute_reply": "2026-07-12T01:46:35.896901Z"
-    }
-   },
+   "id": "90752190",
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Results identical: True\n"
+      "RTs match: True\n",
+      "Choices match: True\n"
      ]
     }
    ],
    "source": [
-    "# Reproducible simulations with random_state\n",
-    "theta = {\"v\": 0.5, \"a\": 1.0, \"z\": 0.5, \"t\": 0.3}\n",
-    "\n",
-    "result1 = ddm_sim.simulate(theta,\n",
-    "                           n_samples=100,\n",
-    "                           random_state=42)\n",
-    "result2 = ddm_sim.simulate(theta,\n",
-    "                            n_samples=100, random_state=42)\n",
-    "\n",
-    "print(\"Results identical:\", np.allclose(result1[\"rts\"], result2[\"rts\"]))"
+    "repeat_out = ddm_sim.simulate(theta=theta, n_samples=1000, random_state=42)\n",
+    "print(\"RTs match:\", np.array_equal(sim_out[\"rts\"], repeat_out[\"rts\"]))\n",
+    "print(\"Choices match:\", np.array_equal(sim_out[\"choices\"], repeat_out[\"choices\"]))"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "6286df13",
    "metadata": {},
    "source": [
-    "**Using other models**: Simply pass a different model name to create simulators for other SSMs:"
+    "## A Basic Diagnostic\n",
+    "\n",
+    "Reaction-time distributions and choice proportions are quick checks that\n",
+    "a simulation has the expected scale and response structure."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-12T01:46:35.898166Z",
-     "iopub.status.busy": "2026-07-12T01:46:35.898118Z",
-     "iopub.status.idle": "2026-07-12T01:46:35.903115Z",
-     "shell.execute_reply": "2026-07-12T01:46:35.902830Z"
-    }
-   },
+   "id": "1186440a",
+   "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Angle model parameters: ['v', 'a', 'z', 't', 'theta']\n",
-      "Sample RTs: [[1.3255601]\n",
-      " [0.896396 ]\n",
-      " [1.3833561]\n",
-      " [2.3548155]\n",
-      " [1.185085 ]]\n"
-     ]
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAGGCAYAAABmGOKbAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlcelbwAAAAlwSFlzAAAPYQAAD2EBqD+naQAASzxJREFUeJzt3Qd4VEXXwPGThIRQE3oNVZHeQekdpAkiIFVAmgVfAVGpCiqiFEFELIANBAsiiICFEgGld3wRQVroPaGGtt9zxnf32w1JSCA32/6/57kke9vO3pDMPXdmzgTYbDabAAAAAACAFBeY8qcEAAAAAAAE3QAAAAAAWIiWbgAAAAAALELQDQAAAACARQi6AQAAAACwCEE3AAAAAAAWIegGAAAAAMAiBN0AAAAAAFiEoBsAAAAAAIsQdAOI16xZsyQgIED++usvj7pCnlouAIDn0/pj8ODBKXrO8PBw6devX4qeE/H78ccfzc9w7dq1XCJ4FYJuwEKDBg0ylYN9CQ4OlgIFCkivXr3k6NGjbr/206dPN+Xau3eveBJPLRcAwPPcuHFDPvnkE2nYsKFkz55d0qZNK4UKFZLGjRvLF198IVevXnV3EZEMc+fONfcAGzdu5LrBZxB0A6lg//79YrPZ5Pz58/L+++/Ld999J3Xq1PHoG4EuXbqYMhcvXlw8iaeWCwCQ+mJiYqRBgwYycOBAadmypWzevFkuXLggy5cvl1q1aslTTz0ln332maVl0Lp9ypQplr4H/tWiRQtzD/DQQw9xSeBVCLqBVJQhQwZzUzBgwADTirtkyRKuPwAAd6l3796mq/GyZcvk+eefN73JQkJCpEiRIjJixAizLUeOHFxfAG5F0A24wf3332++Hj582GX9sWPHpE+fPpI/f35z01CwYEEz9iw2Ntaxz9KlS126rKdPn14qVapkumTHpV3Yn376aXOe0NBQKVGihLz11lvmfMOHDzc3K/by2M+n46USGzu9c+dOefTRRyVr1qzmnKVLl5bJkyebJ892+sRfjz106JB5n9y5c5tyNm3aVA4cOJDotbmbctnfT8+tXfpz5sxpyvef//zHdDu8fv26vPDCC5IrVy7JmDGjaS2/dOnSbe+dlOt/7tw5ee6550zXxXTp0pky6vucOnUq0c8FAEhZu3btkm+++Ua6detm6sH4lC1bVh577LHb1q9atUqqVKli6rGiRYvG2xp+7do1GTlypPk7r3WC1iFdu3aVqKioJI3pnjFjhlStWtXUOxr4azni1qlad2vZtT7JnDmzqSe3bt2a5LHpv/zyi5QvX958jgceeMC8Z0L7auu/lke730+aNMls27Nnjzz++OOObvnai+ztt9+WmzdvOo6317vbt283DzLsdbp239d7griSe87XXntNIiIiJDAwUEaNGiXt2rUz++jPx34PoPsnNqY7Oe+5Y8cOGTNmjOTLl89c9/r169/2c9F7BL2f0Ic3uo9+7du3rxw5cuSOPxsgXjYAlnnhhRc0ErXt37/fZf2rr75q1s+fP9+x7siRI7Z8+fLZKleubFu7dq3twoULtt9++81WqFAhW/PmzeM9/61bt2wnTpywvfPOO7agoCDbnDlzHNsOHTpky5Mnj61MmTK2yMhIW0xMjO2vv/6yDR061LZw4UKzz7Rp00w59uzZc9u5Z86cabbt2rXLse7PP/+0ZcyY0VanTh3bf//7X9uZM2dsU6ZMsQUHB9uee+45x37vvfeeObZHjx62GTNm2M6dO2fbvHmz+SzVq1e/43VLbrns79elSxfbrFmzbOfPn7f98ssvtgwZMphr/eyzz9o+//xzs37ZsmXmM/Tv39/lvEm9/q1bt7bdd999tg0bNtiuXLlifrbvv/++7c0337zj5wIApJyJEyeav/3z5s1L8jG6/yOPPGLr1KmTqWNOnz5t6ghdr/WUM90vU6ZMttmzZ5v6Q//ua52qdeuxY8cc+4WFhZlzOHvqqadsadOmtY0bN84WFRVl3kfL+fTTTzv26devny1dunSmDjl16pTt8OHDtp49e5q6a+fOnXf8HM2aNbO1bdvWtnfvXtvJkydtI0eONOunTp16275ajz322GO2v//+29RbixcvNl+zZs1qq1q1qm3r1q2mrv7kk09soaGhtq5du95W7+p7TZ482dT9ej9Qs2ZNW5YsWWwHDx507Jvcc7Zr1842adIk8/m/+eYbc+5vv/3WbNPrHZfev+i2NWvW3PV76jq9d9H30utcokQJW+nSpc09lV337t3NPcHvv/9u6nq9p5o+fbpt2LBhif5cgIQQdAOpGHRfvHjRtmDBAlNBa8V97do1x74aoGowePToUZdz/PTTT+YcK1asSPS9WrRoYatbt67jtQagWplrJZ5SwW2bNm1MGbWicvb888/bAgICTGXuHAS/8sorLvt99NFHZr1W1lYE3XrD4ezJJ580Ny8jRoxwWd+7d29zI+Usqdc/PDzcNmDAgETLDwCwnj481b/PGzduTPIxun/evHlNIGV3+fJlW+bMmV0C4uXLl5t99aG2M314HRgYaOq9hILudevWmWNfe+21BMuhZdZ9xowZ47L+xo0btuLFi5sA+U6fI0eOHKbsce8FNAC9evWqy77ZsmWzXbp06bY6MiQkxDwUiK9hwB702uvdvn37uuynDx40sO3Tp89dn1Pr47iSG3Qn9z3/85//uOz39ddfm/UaYNvpA3e9LwBSCt3LgVRQuHBh06VJu5i1atXKdHv67bffTDZzu4ULF0rNmjUlT548LsfWq1dPgoKCzP7q1q1bpluYdkfT8zl3v3bO9r148WKTrE27T6UUHTNXt25d03XbWdu2bU33cu265qx58+Yur7Urutq3b59YQbvlOdPrrF3EHn74YZf12s1eE+2cPn062de/XLlyphuidqm/U1d5AIDn0cRr2h3bTrsPaxdz57pJ6zvVpk0bl2O1C3eZMmUc2+OzaNEi87VTp04J7mMfMmXvSm2n9Y3Ws/Y6JzGarV3L7qx169Zy9uzZ27qo677aJdyZfgbtbq5DquLW6fbtzh555BGX19rNXBOaOdf993rOu5Hc90zKvYnW9Tp0Yfz48cykghRB0A2kYvZyHQ88ceJE2bBhg4wbN86xXcccaQD4888/S5o0aUylq4uOb9KxSbr9zJkzZt9XXnlFXnzxRTP2WMcw6ZhlPXeHDh3M2GX7+bTSTcmAW88ZHR1tKtm47Oucg1gVN4DV8Wr2TK9WiPt+mTJlSnS9vRzJuf6zZ882yfD056APU3Rsd//+/RnTDQCpTPNuKM0fkhxx6wR7/eRcN9n/5idU58Wt75ydPHnSfE2sDj5+/LgjiLfXO1rn6PLhhx863j8xOsY8oXVxyxdfWfQ9klOnJ/R+zvsl95wpcZ+S3PdMyr2JjrXXhyY69lvH9GtArzlyPGG6V3gngm4gFWmyFQ3QNOGK/iFfuXKlWa+VrW7TJCsaRGuQp4u2av9vGIhpWVU656gGfZrQQysOPdYe2NvpuixZsqRowg89p1ZMJ06cuG2bfZ0mMHGmLfCpKaH3u1M5knP98+bNK59//rmp5Lds2WIefmjlrD8TAEDqadKkifma3JlAklI32Xt0JVTnxa3vnNmzpSdWB9uP133s9Y7WOfZ6R7/eSWL1cbZs2VzWO/esc/6MyanTE9rX+b2Se874ypVcyX3PpPz89ZiPP/7YPFDXxGt67/bVV1+ZpGvA3SDoBtxAs6GGhYWZFms7Ddq0i1ZiT8/ttPXVmWbd1NbzuHNZave0xCp9ncJMOWfnvlOXvMjIyNtaqnXeca3EtCt2SkhuuVJCcq6/PVDXjLFDhw6V7t27y7p160ymWwBA6tChQu3btzcPoxPK+K0B07x585J9bq3v1Pfff++yXnuY6Tnt2+Oj9a+9Z9Sd9vn666/lbulsJlevXnVZt2DBAvPQvUKFCnc8Xj/D+vXrb2u91Trdvt2ZDsOK26KvWcSd90vuOVPq3uRe3zMh2vNAu59rJvNnn31Wdu/e7ejJACQHQTfgBloh6h9wrSTsFbq2fGtFo+OSNbCNiYkxf9g1ENRpMOzTY+j4p/nz55vxYDpe+Y8//jBBX9ynr6NHjzatt3o+Db4vXrwof//9twwbNswxlsw+jknHfyclYNRpPfTpu33aE+0ur93g3n//fdPtqlixYilyfZJbrpSQlOuv11vH2ukNnE73pjcEmzZtMt3Sq1evbqaUAQCknmnTppnxvFoHvvfee+Zvsw610t5fb7zxhhlzfDdBkp5Px/7qUCId26t1wubNm80YbG3JfvnllxM8VsujvdG0Hp4wYYJ5+K1DvrTufuaZZ8w+Dz74oJl+csiQIWbYmU5DdvnyZTMFl07tOXDgwDuWsXLlyma6NB2LrA+M9fNq/a51ddyH8wlN0aljwrVO16m7dAiZ9uTS99eu1Xp+Z/oeWt9r3a/Ttem10LHx+hnu9pzxKVmypAl2tQdDUgLvlHjPuGrVqmUeiBw8eNCUQc/7ww8/SKlSpZj3HXcnxVKyAUjylGFKp6TSzKMlS5a03bx506zTKT80q2aRIkVMJs7cuXPbGjVqZDJ5akZTewZ0nWZEpyxJnz69mb5Lpznp1q2bLVeuXC7voZnLe/XqZTK16tQlmhFVM6U6ZzV94403bPnz5zfZWLWs9unE4ssSrrZt22amUdEs3lpGnWpDp21xnmrDnk08bibRHTt2mPV67jtJTrkSer8PPvgg3uufUHb0pFx/nUZMpzjRsmnW1qJFi9oGDhxopoMBAKS+69evm+kp69WrZzJ369/vggULmr/fOl2kc6Zy/dv/8ssv33YOrUsffPBBl3VaV+rsF/p3XqfGzJ49u5lq7MCBAy77xTdlmNaJH374oa1ixYqmrsiZM6fJSB63TtVpLmvUqGFm1NDZNsqWLWumpXKekiw+9s+hU3/pbCj6me+//34zS0hC+8ZHs7HrVGB63fQzFitWzDZ69GhzTe3s9a5OxzV48GDzWXR2lAYNGph7gns5p94XxEenEdOfoU6H6nzfEF/28nt9T7130PV6L+Gcgb5z586mDPrzK1y4sLn3utPPBUhIgP5zl/E6AAAAgFSmQ7q0tV1bc602a9Ys6dq1q+lWb++JBiB56F4OAAAAAIBFCLoBAAAAALAIQTcAAAAAABZhTDcAAAAAABahpRsAAAAAAIsQdAMAAAAAYJE0Vp3Ym9y6dUuOHj0qmTJlMlMwAADgCXRWzwsXLkjevHklMNC/n5NTVwMAvLWeJugWMQF3REREav58AABIsqioKMmfP79fXzHqagCAt9bTBN0ipoXbfrEyZ86cej8dAAASERMTYx4K2+spf0ZdDQDw1nqaoFtTuP+vS7kG3ATdAABPw9An6moAgPfW0/49QAwAAAAAAAsRdAMAAAAAYBGCbgAAAAAALELQDQAAAACARQi6AQAAAACwCEE3AAAAAAAWIegGAAAAAMAiBN0AAAAAAFiEoBsAAAAAAIsQdAMAAAAAYBGCbgAAAAAALELQDQAAAACARdJYdWIkT/3xkcm+ZMsH1eUyAwBwN0aGcd3gHUZGu7sEAO4RLd0AAAAAAFiEoBsAAAAAAIsQdAMAAAAAYBGCbgAAAAAALELQDQAAAACARQi6AQAAAACwCEE3AAAAAAAWYZ5uAABgqVu3bpnFWUBAgAQFBXHlAQA+j5ZuAACQZDabTUaMGCG5cuWSkJAQqVatmmzatCnRY9q3b2/2DQ0NdSyNGzfmqgMA/AJBNwAASLIxY8bI1KlT5bvvvpMTJ05IhQoVTAB9+vTpRI/r06eP3Lhxw7EsW7aMqw4A8AsE3QAAIEm0i/ikSZOkf//+UrNmTcmSJYtMnDjRBNGfffYZVxEAgHgQdAMAgCTZs2ePnDp1SurUqeNYlzZtWqlevbr88ccfiR47a9YsCQ4Oljx58kjnzp3lyJEjXHUAgF8g6AYAAEmi3clVjhw5XNbnzJnTsS0+5cuXlx9++EFiYmJk6dKlcujQIWnQoIFcuXIlwWNiY2PN/s4LAADeiKAbAADcc7dzzUaekOHDh0v9+vUlXbp0UqpUKfnqq69k9+7dsnjx4kTHjoeFhTmWiIgIfkoAAK9E0A0AAJJEu4arkydPuqzXLue5c+dO8lXMly+fGQ++d+/eBPcZMmSIREdHO5aoqCh+SgAAr+TWoPvmzZsyf/586dixowwaNOiOT9Gffvppad26tZw5c+a2bZ988okZI9azZ0/5+eefLS45AAD+p2jRomaqsBUrVjjWXb16VX7//Xczrtu5XtY6PiEaQJ87d84E3wnRseKZM2d2WQAA8EZuC7qvX79uKm8NlvWJeWRkZKL7v/766yaYXrBgwW1jwHr16mXmDNW5QgsVKiSPPPKIfPzxxxZ/AgAA/EtgYKC88MILJoO5js0+fvy49OvXz3Qb7969u2O/Nm3amDHbShOm6cP1DRs2mHHZOqe3zttduHBhefTRR934aQAASB1pxE2CgoJk9erVkj9/fjP1iH6fkFWrVsnnn38uY8eOlXbt2rls27Ztm3z66acmaLdnU9WbgsGDB0u3bt3Mk3IAAJAytGeaJjl78skn5ezZs1K5cmX59ddfJWvWrC51vC5KW7M1yB4wYIDs3LlTsmfPLg0bNpRRo0ZJhgwZ+LEAAHye24JuDYw14L4TrdC7dOligm6dBzSuJUuWmAq8du3ajnUamGvSlrVr17pMawIAAO6NJkzTOlaXhHz33Xcur7VFm1ZtAIC/8vhEaj169DDd0urWrRvv9v3795vg3TlraoECBRzb4sM0JAAAAAAAn27pTorJkyfL4cOHZe7cuQnuowF0+vTpXdaFhoaabm2a3CWhaUi0W5u3qz8+8XHw8Vk+KP6HFwAAAAAAPwu6NVGLjhGzj+PWKUnsidN0nWYq17k7NQOqs/Pnz5usqTodSULTkAwcONDxWhO7MP8nAAAAAMCvgu4PP/xQLl++7Hi9fft2+eOPP0zAXbVqVbOuXLly8tFHH8mFCxckU6ZMZt3WrVvN17Jly8Z7Xk2uRoI1AAAAAIBfB92NGzd2eZ0xY0bztUmTJo4kbK1atTLZz9977z0ZOnSomRt0woQJUqlSJSlRooRbyg0AAAAAgNuD7ueff14OHjwoO3bsMFnKW7dubdZ/9dVXZlx2UmTLlk1mzpwpXbt2le+//950Lb927ZrJag4AAAAAgN8G3dpKreOp4woODo53f+1KroG1ThEW9zyHDh2SDRs2mG7jDz30kISEhFhWbgAAAAAAPD7orl+/frL2z5Ejh6M1PK7w8HBp1KhRCpUMAAAAAAAfH9MNAAAAwEuMDHN3CYCkGRktqSkwVd8NAAAAAAA/QtANAAAAAIBFCLoBAAAAALAIQTcAAAAAABYh6AYAAAAAwCIE3QAAAAAAWISgGwAAAAAAixB0AwAAAABgEYJuAAAAAAAsQtANAAAAAIBFCLoBAAAAALAIQTcAAAAAABYh6AYAAAAAwCIE3QAAAAAAWISgGwAAAAAAixB0AwAAAABgEYJuAAAAAAAsQtANAAAAAIBFCLoBAAAAALAIQTcAAAAAABYh6AYAAAAAwCIE3QAAAAAAWISgGwAAAAAAixB0AwAAAABgEYJuAAAAAAB8OejevXu3/P333wluj42NlT179sjly5cT3OfWrVtmn6ioKItKCQAAAACAlwTdNptNPvroIylfvrxUrFhROnXqdNs+e/fulQ4dOkj27NmlWbNmki1bNunatettwfeaNWukSJEiUqNGDSlRooRUr15djh49moqfBgAAAAAADwq6r1+/Lps3b5ZPP/1UevfuHe8+27Ztk0cffVTOnz9vWrG1RXzlypXy0ksvOfa5ePGi2eeRRx6REydOyKlTpyQgIEC6deuWip8GAAAAAAAPCrpDQkJMS3eFChUS3Oexxx6Txx9/XIKCgszrAgUKSLt27WTFihWOfX744Qc5ffq0vPrqqybYTpcunQwdOlSWLl0q+/fvT5XPAgAAAACAx47pTo7t27dLwYIFHa83bdokRYsWNV3P7apVq2a+aks6AAAAAADukka8yBdffCHLli2T5cuXO9adOXPGJeBWWbJkkcDAQNMCnlBiNl3sYmJiLCw1AAAAAMBfeU1L9+LFi83Y73fffVfq1KnjWB8cHOwSQNvHi2s2c90WnzFjxkhYWJhjiYiIsLz8AAAAAAD/4xVB908//WTGd7/11lvSr18/l20aMB87dsxlnT1zeULB9JAhQyQ6OtqxMM0YAAAAAMAvg+5ffvnFZCcfPXq0DBgw4Lbt9evXN0H31q1bHet+/PFHk1DNPrY7rrRp00rmzJldFgAAAAAAfGpMt04BduXKFTPNl361B85ly5Y1Y7J1erBWrVpJx44dTXBt367ZzMuUKWO+r1mzpjRt2lQ6d+4sY8eOlbNnz8qwYcNk8ODBkjFjRnd+PAAAAACAn3Nr0K3B8d69e833Ov66e/fu5vs1a9aYlmoNsh944AGThdy+TWXKlElWrVrleP3tt9+arudvvvmmacXW4LtPnz5u+EQAAPi+HTt2yGeffWYedFeuXNnkXNGpQJNi3rx58s0335gpQbUnGwAAvi7AZrPZxM9p9nJNqKbju93V1bz++EjxVMsH1XV3EQDAL3lC/RSX9kJr1KiR9OjRQ0qVKiVTp06VPHnyyNKlS00vtcTs2bPH9FzTz/PSSy/J8OHD3XctRobd+zmA1DAy2nuuM79X8LPfq5gk1k0eP6YbAAB4joEDB0r79u3lww8/lOeee87MLvLbb7/J999/n+hx165dkw4dOsi4ceM85gECAACpgaAbAAAkyYkTJ2TTpk3Srl07x7rChQtLlSpVZNGiRYke++KLL5qWcQ28AQDwJ24d0w0AALzHvn37zNcCBQq4rC9YsKBjW3x0VpGFCxe6zDRyJ7GxsWZx7sIHAIA3oqUbAAAkydWrV83XuLOD6Gv7triOHDkiPXv2lC+++CJZ3crHjBljxsnZl4iICH5KAACvRNANAACSRINfpVnLnZ05c0bCw8PjPWbGjBnm65QpU0zXcl30eM1grsF4QoYMGWIS09iXqKgofkoAAK9E93IAAJAkxYsXN1OD7dy5U6pWreoyhVibNm3iPUbXFytWzGXdr7/+KiVKlJDmzZsn+F46BaguAAB4O4JuAACQJOnTp5fWrVvLBx98IJ06dZLQ0FCZP3++7N+/37y2mzBhgly6dEleeeUVKV26tFmcDRo0SMqUKZNgoA4AgC+hezkAAEiyd99914zf1pbqhg0bmmBbx19XqFDBsc+qVatk+fLlXFUAAGjpBgAAyZE7d27ZsmWL/PHHH2Zsto7Z1uzlcVuydV7uhEydOlXuu+8+LjwAwC/QvRwAACTv5iFNGqldu3aC22vWrJno8Y888ghXHADgN+heDgAAAACARQi6AQAAAACwCEE3AAAAAAAWIegGAAAAAMAiBN0AAAAAAFiEoBsAAAAAAIsQdAMAAAAAYBGCbgAAAAAALELQDQAAAACARQi6AQAAAACwSBqrTuzP6o+PdHcRAAAAAAAegJZuAAAAAAAsQtANAAAAAIBFCLoBAAAAALAIQTcAAAAAABYh6AYAAAAAwCIE3QAAAAAA+OKUYTdu3JD58+fL119/Lfnz55eJEyfets/NmzdlxowZsmzZMgkNDZX27dtL8+bNk70PAAAAAAB+09J9/fp1KVKkiMyePVvOnz8vq1atine/Hj16yOuvvy716tWT4sWLy2OPPSYffPBBsvcBAAAAAMBvWrqDgoJk3bp1kidPHunfv7+sXr36tn22bNkiM2fOlJUrV0qtWrUc64cOHWoCbW3VTso+AAAAAAD4VUt3YGCgCbgT89NPP0mOHDmkZs2ajnVt27Y1LeNr165N8j4AAAAAALiDRydS279/v+TLl08CAgIc6yIiIhzbkrpPXLGxsRITE+OyAAAAAADgV0H3tWvXJH369C7r0qZNa7qm67ak7hPXmDFjJCwszLHYg3QAAAAAAPwm6A4PD5ezZ8+6rNNu45qtXLcldZ+4hgwZItHR0Y4lKirKwk8BAAAAAPBXHh10lytXTvbt2ycXLlxwrNu6datjW1L3iUtbwjNnzuyyAAAAAADgV0F3q1atTPbxSZMmmde3bt2S8ePHS5UqVczUYEndBwAAAAAAv5oyTD377LNy8OBB+e9//2u6iLdo0cKsnzt3rgmks2bNKl9++aV06dJF5s2bZ7qCq8WLFzvOkZR9AACAmKk6169f76gr7TQ3ysCBA7lEAABYwK1B9+OPPx5v5vDg4GDH9xqI65jrjRs3mm7h2oLtvD2p+wAA4M9effVVef31100vsLjDqjQHCkE3AAA+GHTXrl07SftlypRJ6tWrd8/7AADgj2w2mxl6tXTpUqlfv767iwMAgF/x6DHdAADg3ukUmoGBgQTcAAC4AUE3AAA+Tode3X///bJ9+3Z3FwUAAL/j1u7lAAAgdVq6GzZsKM2bN5f+/ftLwYIFbwvKW7ZsyY8CAAALEHQDAODjLl68KB9//LH5XpOpxZUtWzaCbgAALELQDQCAj9PpNc+fP+/uYgAA4JcY0w0AAAAAgEVo6QYAwE9cunRJvvnmG9m9e7cEBwdLmTJlpE2bNpImDbcDAABYhZZuAAD8wKZNm0wGc02ktmLFClm0aJF0795dypUrJ0eOHHF38QAA8FkE3QAA+IG+fftKixYt5OjRo7Ju3TrZvHmzHDp0SPLnzy+DBw92d/EAAPBZ9CcDAMDHXb582czRvWrVKkmXLp1jffbs2WXChAnSrFkzt5YPAABfRks3AAA+LigoSGw2m8TGxsY7zjskJMQt5QIAwB8kO+jWcV8HDhxI9jYAAOAeadOmlbp160qnTp1k//79jvVbtmyRPn360NINAIAnBd1z5syRKVOmJHsbAABwn+nTp8vZs2elSJEiEh4eLhkzZpSKFStKwYIFZfTo0fxoAADwhjHd58+fl8yZM6fkKQEAQArQ4Hrt2rWyZs0aM2WYThNWtmxZswAAAA8IuhcvXiyzZ8+WXbt2yZUrV+T48eO3jQn79ddfZd68eVaUEwAApIBq1aqZ5V7o+PCtW7ealnMN2nPkyHHHY3Q8uSZzu3btmhQvXlyyZct2T2UAAMDngu7AwEDzVFy/2r93FhERIZ9//rk0btzYinICAIBk0CBXh32FhobKo48+ar5PiO7ToUOHJJ33zJkz0rRpUzPdmLae79ixQ8aNGyfPPvtsgsd8+OGHMmbMGMmXL5/cvHnTHDNo0CB57bXX+JkCAHxekoPuhx9+2Cy//fabXLhwwcz1CQAAPHeasOHDh0vWrFmlSZMm5vuE6D5JDbr79+9vAvp//vlHMmTIIF999ZV07txZ6tSpI6VLl473GJ2mTANt+xC0JUuWmORtei9RtWrVu/yEAAD46JhurVQBAIBny5Ilixw+fNjx2vn7u6XDy7799luZPHmyCbiVBuuDBw+WWbNmyVtvvRXvcd26dXN5XaFCBfNVu6cDAODr7iqRmk4xolnKddoRHZvlrGPHjol2MQMAAKlLu4RXqlQp3mk9E9sWlyZg01bucuXKuazX19u2bUv0WJ1WVO8fzp07Jx999JG0bt1aGjVqlOD++j7O84rHxMTcsXwAAPhE0H3w4EGpVauWWTQRS3BwsMv2+++/PyXLBwAA7pEmPrt48WK82/Th+fXr15M8S4m9O7ozTYqmiVYTs2fPHjO2+8SJE6bVvUePHhIUFJTg/joGfNSoUUkqFwAAPhV0L1261ATcOh4LAAB4Lm0p1u7gGnDr99oF3JkmNVu+fHmSH5iHhIQ4xos709f2bQmpW7euWVRkZKQ0bNhQcuXKlWCOmCFDhsjAgQNdWro1aSsAAD4fdKdPn55KDwAAL6DTeWqWcG3ptn/vTAPl++67T955550kna9w4cLmq7ZUO3cxj4qKSlZPNw2+H3jgARPwJxR0p02b1iwAAHi7wOQeULt2bVm5cqUZAwYAADyXdgM/fvy4GYtdo0YN873zotN+aeBbsWLFJJ0vT548Zl7uefPmOdZpAL5u3Tozw4ndxo0bZc2aNeb7q1ev3tYyrt3UNVDPmzdvin1WAAB8pqX7zz//lICAAClevLjUr19fMmXK5LJdpyVp165dSpYRAADcA23R1jo7Jeic3M2bNzfZ0XWKsEmTJplpv5zr/jfeeMME1tqNPDo62ry3JlrV1u1Tp06ZRGoawPfs2TNFygQAgE8F3ZpwxblLWdzELHGzmcP71R8fmexjlg/6d9weAMD9bt26JRMnTkyRxGSNGzeW1atXy4wZM+THH380U4Y999xzLknRqlSp4rg/0HHb2po+bdo0mTt3roSHh5v9u3btSvdxAIBfSHbQrWOvEhp/BQAAPE/GjBklf/78snnz5iR3JU/Mgw8+aJaEDBs2zOW1Bt7Dhw+/5/cFAMBv5ulObToeTKcq0+5xmrk0TZrbi60ZWP/++28JDQ11JHoBAAD/9kLTLuHNmjWTZ555RooVK+ZSl2rCspYtW3KpAADwhKB7wYIF8umnnya4vXXr1tK9e3dJKW+++aaZq1OTrWjmVe0iN3XqVPM+dr///rvp3qaBt+6jY8a+//57yZcvX4qVAwAAb6VdvbV7t4ovU7nOs03QDQCAh2Qvt3dRc140mYp2Wdu2bZsZq5VS1q9fb7qo6byimnlVM6Q+8cQT0qlTJzPfqP1Gok2bNtK2bVs5evSonDx50jyx17FiAADg3yzmmtgsoeWff/7hMgEA4Ckt3Q0aNDBLXDodSLVq1aRIkSIpVTY5duyY+VqvXj3HOv3+7bffNjcJOkZMW97Pnj0rI0aMMNs14B46dKjpQrdv374ULQ8AAAAAAG4Z050+fXpp1aqVLF261MzhmRJ0zs/q1atL79695emnnzZdx1955RWT9VQDbqUt7BpY61N8O3tyF/s2AAAgph795ptvTO+x4OBgKVOmjOktFl+uFAAAkDJStJbVlmWdszOl2Fute/XqZQJobU3PnTu39O3b17HPmTNnzFg0Z9rdPTAw0GyLj3ZNt3dPVzExMSlWZgAAPNGmTZvMuG0NvIsXLy7Xr1+XCRMmmGnEfvnlF/KgAADgKUH3qlWrZNGiRS7rNIHZjh07JDIyUoYMGZJihdPzaev5Dz/8YLqL22w2ee2116RWrVrmKX2OHDnMk3rnAFrpjYQmXNNt8dHEbCkxVykAAN5CH1jrlJ86X3eGDBnMutOnT0vnzp1l8ODBMnPmTHcXEQAAn5TsRGrHjx+XjRs3uiwacBcoUEBWr14tpUqVSrHC6XhtndZEA24VEBAgAwYMkHPnzsmKFSvMOn1fTaDm7MiRI45t8dEHA9HR0Y4lKioqxcoMAICn0Z5i27dvl3fffdcRcKvs2bOb1u7ffvvNreUDAMCXJbulu127dmZJDdptXLuIa8u1vdXanlzN3qVck7rpOG/tfl6xYkWzbuHChWaM+UMPPZRgt3VdAADwB0FBQaa3mPYMS5cuncs27W4eEhLitrIBAODrkt3SnZq6dOkiV69elY4dO8qyZctMN3OdLkwTv9SsWdPso4nWmjdvbrrH2ecQHz58uBkLrtObAQDg7/RBc926dU0dun//fsf6LVu2SJ8+fRw9ygAAgIcE3dry/N5770njxo2lZMmSprVZx0lfuXIlRQtXqFAhk/hFM5WPHj1apk6dagJs7Qbn3FL97bffSocOHeSdd96ROXPmmPFqOr83AAD41/Tp080UmzqrR3h4uHkwrT3EChYsaOpYAABgjQCb9jdLBt1dg+ytW7dK+/btJSIiwozznjt3rgmO161b53VdtzV7eVhYmBnfnTlz5ns+X/3xkeLvlg+q6+4iAIDXS+n6Sa1Zs8YkI9VpwnSKz5Sa5tPrrsXIsJQoFmC9kdHec5X5vYKf/V7FJLFuSvaY7l9//VX27Nkju3btcsyVrfQpebVq1eTrr7+WJ5544u5LDgAALKN1tS4AAMBDu5f/9ddf8vDDD7sE3Eoj+zZt2pin5wAAwPPolJ86frto0aJSokQJ02Ntw4YN7i4WAAA+LdlBd86cOc20IzoPdlyaQVznzgYAAJ7lzTffNA/HtZ7u16+fPPnkk3Lt2jWTkHTevHnuLh4AAD4r2d3LNZHZwIEDpWXLltK3b1/Jly+fnDhxQj777DMzT/e0adOsKSkAALgrN27cMAlP58+fL02bNnWsf/HFF00S0jfeeMME5AAAwANaujNlyiSRkZEmoZpW0JUrVzYBuAbeuj5v3rwWFBMAANxL0H3z5k0zPCyu1q1bmwQwAADAQ1q6VbFixWTx4sVm6rCjR49K7ty5vS5jOQAA/iI0NNSM4161apXUrl3bZdvSpUvN1GEAAMADgu5Lly6ZFm6d21MFBweb+T3V5cuXzVN0bQkHAACeQ8duN27cWFq0aCE9e/aUcuXKmdZvnT5s1qxZpuu5Tv2p9CG69mADAABuCLq1En711VelTp06t207ePCgdOjQwczfHRAQkELFAwAA9+rixYsyY8YMCQwMlE8//dRlW7p06eS1115zvM6WLRtBNwAA7gi6d+zYIefPn4834FY69YgmVdNuao0aNUrJMgIAgHuQNWtWU4cDAAAPDrq3bdsmZcqUSXSf0qVLm+nECLpRf3xksi7C8kF1uWgAAAAA/Dfo1ifkdxqvrdvPnTuXEuUCAAApTHOzfPPNN7J7926Tl0UfputMJGnS3FVeVQAAkJJThmnCtPXr1ye6j24vXLhwUk8JAABSyaZNm+T++++X/v37y4oVK2TRokXSvXt3k1TtyJEj/BwAAHB30F2vXj3Zs2ePTJs2Ld7t8+fPl2XLlkmzZs1SsnwAACAF9O3b12Qv16k+161bJ5s3b5ZDhw5J/vz5ZfDgwVxjAAAskuT+ZDpN2Lvvvmueis+ePVsefvhhkzjt+PHjEhkZaZ6YT5gwQfLkyWNVWQEAwF3QaT0154rO063Zyu2yZ89u6m4emAMAYJ1kDeJ64oknTAWt04YNGTLEzNltT6D21VdfyeOPP25VOQEAwF0KCgoydXZsbKxL0G0f5x0SEsK1BQDAIsnOnKJPw3W5cOGCnD17VsLDwyUsLMya0gEAgHuWNm1aqVu3rnTq1Enef/99R/6VLVu2SJ8+fWjpBgDAE8Z0x5epXJOrEXADAOD5pk+fbh6WFylSxDww12FjFStWNHX56NGj3V08AAB8FnOEAADgBzS4Xrt2raxZs8ZMGabThJUtW9YsAADAOgTdAAD4uPPnz0vjxo3N1J7VqlUzCwAA8PDu5QAAwDukT59e/vzzT7l586a7iwIAgN8h6AYAwMdpdnKd6nPatGnuLgoAAH6H7uUAAPi4ixcvmrm6n376afn444+lWLFiZky3c3LUDz74wK1lBADAVxF0AwDgB3LlyiXdunWLd5tzAA4AAFIWtSwAAD5Ox3J3797ddDPXacJCQ0PdXSQAAPwGQTc8Qv3xkck+ZvmgupaUBQB8iU4T1rJlSzl9+rR5fd9998mvv/4qhQoVcnfRAADwCyRSAwDAh/Xv31/q1q0rmzdvltWrV0u2bNlk5MiR7i4WAAB+g5ZuAAB8uFv51q1bZenSpZIxY0az7v3335euXbu6u2gAAPgNrwi69+zZI9OnT5f9+/dLhQoV5PnnnzdzjjrfVMyYMUOWLVtmxqm1b99emjdv7tYyAwDgbufPnzfBtj3gVgULFpRTp065tVwAAPgTj+9e/tNPP0m5cuXMjYMG0xpgd+nSxWWfHj16yOuvvy716tWT4sWLy2OPPcbUJwAAv2ez2eTWrVty+PBhx3Ls2DFTl8ZdBwAA/LCl+9KlS6YL3LPPPivjxo1zrNcA3G7Lli0yc+ZMWblypdSqVcuxfujQoSYYJ0MrAMCfnTt3TiIiIm5b77xOx3nbE60BAAA/CroXLlxobgI0CYyz8PBwl5bwHDlySM2aNR3r2rZta4JuzdiqyWMAAPBHYWFhJlP5nehUYgAAwA+D7u3bt0u+fPlM4K2ZVi9fvmzGdD/99NOSIUMGs4+O89Z9AgICbnt6r9viC7pjY2PNYhcTE5MqnwcAgNQUHBwsDRs25KIDAOBGHj2mW4PsixcvSqdOnaRKlSrSpEkT+fLLL6V69eqOoPnatWsuSdVU2rRpJSgoyGyLz5gxY8zTf/sSX7c7AAAQv3fffVdKlSolefLkMXOA7969O9FLtWbNGpOXRecGL1mypPTr149kbgAAv+HRQXeWLFkkOjpapk2bJn369JEnnnhCfvzxR9MCrl/tXc3Pnj3rcpyO+dYkMc7d0J0NGTLEnNe+REVFpcrnAQDA27333nsybNgwGT16tMmnopnR69evn2CvsRMnTsigQYNM0B0ZGSmzZs2SjRs3StOmTU1dDQCAr/PooLt8+fLma9GiRR3r8ubNa5KjnTx50rzWzOb79u2TCxcuOPbROUnt2+KjLeGZM2d2WQAAwJ2zob/11lsm10rr1q3l/vvvN1N26sPuzz77LN5jcuXKJb///rvJt6It3RUrVpTJkyfLpk2b5M8//+SSAwB8nkcH3dqdXINszU5u991335lu49rFXLVq1coE4ZMmTTKvdWqU8ePHm+7oOn0YAABIGfqQ++jRo9KgQQPHOh3iVaNGDVm9enWSz6NDx1S6dOn40QAAfJ5HJ1LTYPrbb7+VNm3ayOzZs83rHTt2mLFk9lbsrFmzmnHeOnf3vHnzTHdxtXjxYjeXHgAA33LkyBFH67WznDlzyoEDB5J0Dn1wrjOM6MNzbSlPCElPAQC+wqODbqWV8sGDB2X9+vUSGBhoErfEHavdokULMy5bx4hp13Ft5daMrQAAIOVpfewsTZo0puv5nWhvtCeffFIOHTokf/zxR6L7atLTUaNG3XNZAQBwN48PupUG0rVq1Up0n0yZMkm9evVSrUwAAPgbbdFWOpWnM82zYt+WWMDdq1cvWbZsmaxYscKM706MJj0dOHCg47UmamO2EQCAN/LoMd0AAMBzaHdwHda1atUqx7rr16+bKcEefPDBBI/TVvDevXuboV/Lly9PUs4Vkp4CAHwFQTcAAEiSoKAgefbZZ03yUp0p5OrVq2Z8trZid+/e3bFf586dzdAve8Ddt29fE3BrC3eJEiW42gAAv+IV3csBAIBnePXVV01X75o1a5qgW1utFy1aJLlz53bsc+nSJUeG8r///lumTZtmWq6rVavmci5NhNq8efNU/wwAAKQmgm4AAJCs1m5t6Z44caLJMK4zi8SlwbQ9sZp2ST937ly858qQIQNXHgDg8wi6AQBAsgUEBMQbcMcNpjXTedxZRwAA8CeM6QYAAAAAwCK0dMNr1R8fmexjlg+qa0lZAAAAACA+tHQDAAAAAGARgm4AAAAAACxC0A0AAAAAgEUIugEAAAAAsAhBNwAAAAAAFiHoBgAAAADAIgTdAAAAAABYhKAbAAAAAACLEHQDAAAAAGARgm4AAAAAACxC0A0AAAAAgEUIugEAAAAAsAhBNwAAAAAAFklj1YkBT1R/fGSyj1k+qK4lZQEAAADg+2jpBgAAAADAIgTdAAAAAABYhKAbAAAAAACLEHQDAAAAAGARgm4AAAAAACziVUH37t27Ze3atXLt2rXbtt24cUN27Nghe/bscUvZAAAAAADw2qB727ZtUqFCBalWrZqcPHnSZdvKlSulQIEC0qxZM6latapUrFhRoqKi3FZWAAAAAAC8Jui+dOmSdOzYUZ555pnbtl24cEHatm0rnTp1MoH2iRMnJFOmTNK1a1e3lBUAAAAAAK8Kuvv16ycNGzaUhx9++LZtCxYskHPnzsmwYcPM65CQEBkyZIj89ttv8s8//7ihtAAAAAAAeEnQPWfOHNmwYYOMHTs23u2bN2+WokWLSpYsWRzrHnzwQfN1y5YtqVZOAAAAAADiSiMeTFuq//Of/8iyZcskNDQ03n3Onj0rWbNmdVkXHh4ugYGBcubMmXiPiY2NNYtdTExMCpccAAAAAAAPb+nu2bOnSY52+fJlk7V8165djhbsgwcPmu+Dg4NdAmh1/fp1uXXrltkWnzFjxkhYWJhjiYiISIVPAwAAAADwNx4ddGuXcZ0mrH///mb54IMPzPpXX31Vvv/+e/N9wYIF5ejRoy7HHTlyxLEtPjrmOzo62rGQ6RwAAAAA4Hfdy+2Btd3SpUulUaNG8sMPP0j+/PnNugYNGsiIESNk48aNUrlyZUdytQwZMshDDz0U73nTpk1rFgAAAAAA/DboTgqdt/uRRx6Rzp07y5tvvmnGeGsQrtnMNfAGAAAAAMBdvCro1vHXmpk8biv1119/LRMmTJCpU6eabVOmTJFu3bq5rZwAAAAAAHhd0F2lShWTUC0uzWyuLdv2uboBAAAAAPAEHp1IDQAAAAAAb0bQDQAAAACARQi6AQAAAACwCEE3AAAAAAAWIegGAAAAAMAiBN0AAAAAAFiEoBsAAAAAAIsQdAMAAAAAYBGCbgAAAAAALELQDQAAAACARdJYdWIAAOCbDhw4IHPmzJGzZ89K5cqVpV27dhIYmPhz/NOnT8vnn38u+/fvl2HDhkmePHlSrbwAALgTQTdwB/XHRyb7Gi0fVJfrCsAnbdq0SerWrStNmjSRUqVKyYsvvihff/21zJs3L8Fj3n77bZk8ebLUqFFDvv32W3nqqacIugEAfoPu5QAAIMn69+8vjRo1krlz58qoUaNkyZIl8v3338vixYsTPEYD9H379snQoUO50gAAv0PQDQAAkuTMmTPy+++/S5cuXRzrtLW7YsWKsmDBggSPK1++vKRNm5arDADwS3QvBwAASbJ3716x2WxSuHBhl/VFihSRPXv2pOhVjI2NNYtdTEwMPyUAgFeipRsAACTJlStXzNdMmTK5rM+cObNcvnw5Ra/imDFjJCwszLFERETwUwIAeCWCbgAAkCQZM2Y0X8+fP++y/ty5cybwTklDhgyR6OhoxxIVFcVPCQDglQi6AQBAkjzwwAMSFBQku3btclmvr0uWLJmiV1HHgGsg77wAAOCNCLoBAECSaLfyZs2aybRp0+TGjRtm3fLly+Wvv/6Sxx9/3LGfbn/33Xe5qgAAkEgNAAAkh863rfN0V6lSxbR861RhOld3tWrVHPssWrTIdEF//vnnzetly5aZacVOnz5tXr/55puSNWtWad++vdSuXZsfAADAp5G9HAAAJFmhQoXkzz//lJ9//lnOnj0rgwcPNlOCOevTp49L5vFs2bJJ8eLFzfc1a9Z0rM+SJQtXHgDg8wi6AQBAsmTIkEHatGmT4Hbtgu5Mg/K4gTkAAP6CMd0AAAAAAFiEoBsAAAAAAIvQvRzwEPXHRyZr/+WD6lpWFgAAAAApg5ZuAAAAAAAsQtANAAAAAIC/di/funWrfPnll7Jv3z6JiIiQnj17SpkyZVz2uXHjhnz88cdmHtDQ0FB5/PHH5ZFHHnFbmQEAAAAA8PiW7hkzZkivXr0kV65c0qlTJ7OuQoUKsnjxYpf9unXrJm+//bY0bdrUTEnSvn17mTJliptKDQAAAACAF7R0t2rVyrRs2z322GNy7NgxGTNmjGMO0M2bN8vs2bNl9erVUqNGDbPu1q1bMnz4cBOwa8s3AAAAAADu4NEt3dmzZ79tXc6cOeXixYuO1z/99JPkyJFDqlev7hKcR0dHy5o1a1KtrAAAAAAAeFVLd1zHjx83rdpPP/20Y92BAwckf/78EhAQ4FinY7/t2+ITGxtrFruYmBhLyw0AAAAA8E8e3dLt7NKlS9K6dWspVKiQDBs2zLH+2rVrki5dOpd9Q0JCJCgoyGyLj3ZPDwsLcyz2IB0AAAAAAL8Lui9fviwtW7Y0X3/++WeXIDs8PFzOnj3rsv/58+fl5s2bkiVLlnjPN2TIENP93L5ERUVZ/hkAAAAAAP7H44PuK1eumID71KlTZkqwuOO8NVu5Tifm3EV8y5Yt5mu5cuXiPWfatGklc+bMLgsAAAAAAH4VdF+9etUE3CdPnpTly5ebhGnxZThPnz69vPPOO+a1tnCPGzdOHnzwQXnggQfcUGoAAAAAALwgkdrYsWNN63blypWla9eujvUZM2aUuXPnmu+1C/mXX34pnTt3lu+++860eOuY7rhzeQOpqf74SC44AAAAAM8Oujt06CBVq1a9bX1wcLDLa52z+/Dhw2bObu06XqlSJZNIDQAAAAAAd/LooLtYsWJmSYoMGTJIrVq1LC8T4G8t8MsH1bWkLAAAAIA/8Ogx3QAAAAAAeDOCbgAAAAAALELQDQAAAACARQi6AQAAAACwCEE3AAAAAAAWIegGAAAAAMAiBN0AAAAAAFiEoBsAAAAAAIukserEAHxD/fGRyT5m+aC6lpQFAAAA8Da0dAMAAAAAYBFaugE/aoEGAAAAkLpo6QYAAAAAwCK0dAPwCIwdBwAAgC+ipRsAAAAAAIvQ0g3Aa8ebJ/d9yKoOAACA1EZLNwAAAAAAFiHoBgAAAADAIgTdAAAAAABYhKAbAAAAAACLEHQDAAAAAGARspcD8BuplVWdLOkAAACwo6UbAAAAAACLEHQDAAAAAGARgm4AAAAAACzCmG4A8ICx44wDBwAA8E20dAMAAAAAYBGfaem+fv267Ny5U0JDQ6VEiRLuLg4AWI4WdbjT/v375ezZs1K8eHHJkCGDZccAAODtfKKle8WKFRIRESFt2rSRWrVqSbly5eTgwYPuLhYAAD4nJiZGGjVqJGXLlpVOnTpJ7ty5ZebMmSl+DAAAvsLrW7q1Im/Xrp307NlT3n77bdPi3aRJE+natausXLnS3cUDAK9uHfe1seb0Drh3L7zwgkRFRcmhQ4ckS5YsMn36dHnyySflwQcflGLFiqXYMQAA+Aqvb+lesGCBCbyHDBliXgcHB8vLL78sq1atkr1797q7eAAA+IzY2FiZPXu2PPfccyZ4VvrQO2fOnPLFF1+k2DEAAPgSr2/p3rJlixQpUkTCw8Md66pWrerYdt9998V7A6CLXXR0tPmqwXtKuHH1UoqcB4D/uJu/P6nxt6b2G4uSfcyP/6mV7GNaTF6VKu9zN9csudfgbsp1p/8XNptNPMHu3bvl8uXLUqlSJce6gIAAqVy5sqlzU+qY1KirJdYzrilwRyn1fz418HsFP/u9ikliPe31QbcmZMmWLZvLOg3AAwMDzbb4jBkzRkaNGnXbeh0XDgDuEDbCd657an0WT71mVpTrwoULEhYWJu5mr1fj1rv6eteuXSl2jKKuBv7nLff/7gM+562wVK2nvT7o1u7kV69edVl37do1uXXrloSEhMR7jHZFHzhwoOO17msP3vXpu7fSJy364EDHzWXOnNndxfFIXCOuE/+f+L3zpr9P+uRcK/K8efOKp9S5Km69e+XKlQTr3Ls5xpfral9F/Qrwe+WPbEmsp70+6C5YsKAsXLjQZd2RI0fM1wIFCsR7TNq0ac3izLl7urfTmzWCbq4R/5f4nfM0/G26u+vkCS3cznWuvZ4tU6aMY72+tm9LiWP8oa72VfyeA/xe+ZuwJNTTXp9ITacgOXHihKxfv94luVrGjBmlWrVqbi0bAAC+JH/+/GaO7R9++MGx7uTJk7JmzRpTH9tpt/EdO3Yk6xgAAHyV17d063Qjjz76qHTu3FneeOMN0/VsxIgR8uqrr0r69OndXTwAAHyKjrVu27at6UpXunRpGTt2rJQqVUo6duzo0jX8/PnzEhkZmeRjAADwVV7f0q3mzJkjvXr1kk8++USWLFkiH330kbz44ovib7Qbnj5siNsdD1wj/i/xO+dO/G3yrevUunVrU9du375dpkyZIrVr15YVK1Y4xm6rkiVLunQlT8ox8G7e8v8X8Cb8XvmOAJunzEMCAAAAAICP8YmWbgAAAAAAPBFBNwAAAAAAFiHoBgAAAADAIl6fvRz/io2NlU2bNknu3LmlSJEiXJZ4aPqCvXv3ys2bN801CgkJ4TrF49atW/L333+b66XXiaQ4iduzZ4+ZtrB8+fJmqkL869KlS7Jly5bbLkfZsmVd5qCG6/+l69evS4kSJSQgIIBLA6+kdezGjRvN77n+XwZw9/S+9fjx42Ya5KCgIC6lFyORmpfTKdLeeust+fLLL830LD169DCZYeHq/fffl7fffltCQ0PN63Pnzsk777wjXbt25VI5+fjjj83Ue3qzdPXqVcf/rz59+nCd4rF//36pVKmS+f+0YcMGqVy5Mtfpf7Zu3SoVKlQw0zqmSfP/z3c/+OADl6zWEFm/fr1069ZNoqOjJU+ePCZo+eqrr8zc1oC3uHLliowbN05mzJhh/ibWr19f5s+f7+5iAV7pxx9/lPHjx5sZH/T3SZfw8HB3Fwv3gO7lXu7IkSOSLVs2c4PLjWzCTp8+LWvXrjUtuLq8/vrr5gHFf//731T8aXlP6+TOnTvN01UNuJ966inZt2+fu4vmcbRFUucY5oHEnW8cVq9e7Vj4O+Xq0KFD0qhRI2nevLkcPnzY9FjSgPvo0aMW/u8FUp4GBTdu3DC/540bN+YSA/fgzz//NFPwffHFF1xHH0HQ7eX0Bvbll1+WHDlyuLsoHk3/cOXNm9fxunfv3uarBuL4fwMGDDAPcezq1atnupkfO3aMyxTHsGHDpHDhwtKlSxeuTSL++ecf81Dw4sWLXKd4aEuGtl7oA67AwH+rZG3h1lZCwJtoHfvaa69JRESEu4sCeD29t9d7MPgOxnTDL2lrrnbhvO+++9xdFI+jAbYGSto7YOLEidKyZUszlgj/75dffpFvvvnGBJPaOomEtW3b1ox11/9Tffv2NcM6goODuWT/s2zZMmnatKnJpbB582bJmjWrFCxYkDHdAAD4EIJu+GUX6l69ekmdOnWkVq1a7i6Ox1mzZo0JjHTogj6Y+PDDDx0tcBCTNK179+4yZ84c00JJ0B2/sLAw+fnnnx3dTLXbtLbealA5atQo/iv9j3Yj1265mnAqU6ZM5vcuX7585v8XSagAAPAN3EnDr2hysNatW8u1a9dMSyUZgm/Xpk0bMyZPk4SNHj1aWrRoYZKE4V/PPfecVKxY0WQR1etkz9C9bds22b17N5fpf7TrvfO4Tk04p8M6dLwy/p+2+uu49wULFpieE1FRUZIrVy554oknuEzwWL///rsjTwO5UQDgzmjphl9Nq6YBt97URkZGSs6cOd1dJI+n2d1feukl02JZpUoVdxfHI2TJksW0Tg4ePNi8vnz5svn63nvvmf9bI0eOdHMJPZcGk9qSi/9XqFAh83+qdOnS5rXOsKA9KTp37mz+b6VPn57LBY/MaaFJ01SNGjXM7CAAgIQRdMOvAu4DBw7IihUrzHzmuL0XgLa6Oc8DqVOG6eKcXM3fffTRRy6vNdO7JjScPn06U4bFGcaRIUMGl2v166+/OoJL/KtJkya3TaukQxZ0HHy6dOm4TPBI+uAaAJB0BN1eTpPv/PHHH+b7CxcumCRY2t1Lb3Z1jlz8q127dqY73CeffGISOumiNGERmVb/dfDgQdOy/eSTT0rRokXN/6VJkyaZa6StbkByDB8+3Mzb27BhQwkJCZHZs2fLypUrZfHixVxIJ/3795fPP/9cevbsKe3btzd/m3RYh/YwYfgLvI3OCKIt4GfOnDE5QfR+JE2aNPLQQw+5u2iAV9EhftozzD58Q3+39GFsyZIlTW4UeJ8Am84HBK+lN7U6x2tcRYoUYW4/J3Xr1nV0hXOmcywzdvL/6ZjkDz74QHbt2mW6vFavXt0knaOLa+IVoz6smDFjhjzwwAP39gvtYw8EZ82aJYsWLTKt3joNVr9+/Ux3arjS4Qpjx441vSZ02ItmfNfcCoC30Uz82gDgTBMELlmyxG1lArzR5MmTTe6huMaMGUMSYC9F0A0AAAAAgEXIXg4AAAAAgEUIugEAAAAAsAhBNwAAAAAAFiHoBgAAAADAIgTdAAAAAABYhKAbAAAAAACLEHQDAAAAAGARgm4AAADAS3377bdy9OjRez7P999/L4cOHUqRMgFwFWCz2Wxx1gFAogYMGCBr1qwx36dNm1YiIiKkU6dO0qxZMzl48KA8/vjjiR7/1FNPSffu3bnKAADcweXLl2Xjxo1y9uxZU9+WLFlS0qVL59geGhoqc+fOlRYtWtzTtcyePbtMmTJFOnTowM8ESGFpUvqEAHzfrl27JFOmTPL6669LbGysrFixwlT2n3/+ubRr104mTZrk2Hfq1Klmuz6Jt9ObBgAAkDBtF3vrrbdkzJgxct9990mhQoXk8OHDcuLECXn55ZflmWeeSdHL16ZNGylYsCA/EsACBN0A7kq2bNnkoYceMt/XqVNH1q9fLzNmzJCuXbs61qv58+eb1nDndQAAIHEjRoyQd999V3744QepV6+eY/25c+dk8eLFt+1/7Ngx2bZtm4SHh0vVqlUlMNB1FOn58+dNL7UbN26YOjlHjhwu25s2bSr58uVzWXft2jVZu3atXLhwwZwz7jH64F3PefHiRSldurR5MADgdozpBpAicubMKadOneJqAgBwj06ePCnjxo2Tl156ySXgVlmyZJHOnTu7rNNeZbVq1ZL3339fWrVqZYZ7OY8g/fHHH6VAgQIyatQoc14NjrV3mrPevXvLH3/84XitwXSRIkWkV69e5rwadH/33XeO7evWrTPbX3zxRfnwww+lUqVKMnDgQH72QDwIugHcM326/vPPP5sKHwAA3BsdlqWtzNrlO6njvv/8809ZuHChGf+txy9dutRs01bqnj17ygsvvGBarVeuXCljx46VZ599NsEEbNpy3bp1axPA//XXX6ZlfefOnRIWFuZ4P92uQfyGDRtMUL99+3b54osvzPcAXBF0A7grWplr97SKFStK0aJFpVq1ajJ+/HiuJgAA9+j48ePmq7ZOJ8WTTz5phnLZ86ZoC/Tu3bvN6+XLl5skbNoi7ZzQVBOwJRQgL1myRE6fPm3Gk9u7qWfIkEEaNmxovv/pp5/kzJkzkjlzZpPETfO2/P7771K4cGET8ANwxZhuAHelQoUKJpHalStX5LPPPjMt3dodLmPGjFxRAADugSYrVRrY2r9PTNasWV1eawB+9epV873OKpI7d25Jnz69Y3tQUJDpYq7b4qNTh+kxGlTH58CBAxISEiLz5s1zWa8P4TXgB+CKoBvAPSdS0/Fmumj3NZ5wAwBwb3T8tNLu4PeanEynAtPka3Fp67dui48mY9PtOi48ICDgtu0ajF+/fl1mzpwpwcHB91Q+wB/QvRxAipg4caL89ttvZjwZAAC4e5oJvFGjRvLKK69IdHR0vC3RSaUPyDXLuPZIs9u0aZPs379fatSoEe8xDRo0MEG183Sfyp4wVbuZ37x5Uz799FOX7XoMSVWB29HSDSBFlC9fXjp16iRDhgwxWVO16xoAALg72orcsmVLKVeunOlJpnNoHzlyRFavXm26nH/11VdJOo929x4wYIB07NjRzO+t3cI1g/kTTzzhaFGPS1vXX3vtNenWrZtJlFasWDHzYF3nCx85cqTZrsnY+vXrZ6Yp0/wu+iBAx3e/9957Ur9+fX7sgJMAm/N8AgCQBJrJNE2aNKbydabd1zRxi94gpEuXzqyLiooyY9I0KAcAAEl369Yt04NMh25pHatJ0mrXri2NGzd27KPBswbVmmvFbvDgwVKzZk1p0aKFY52Ov9YEaNpCrUPC9EG581zeffr0kR49epjEqHYaaOtxmr9Fj9HA3dn69etNoK05XfSeQM/JmG7gdgTdAAAAAABYhDHdAAAAAABYhKAbAAAAAACLEHQDAAAAAGARgm4AAAAAACxC0A0AAAAAgEUIugEAAAAAsAhBNwAAAAAAFiHoBgAAAADAIgTdAAAAAABYhKAbAAAAAACLEHQDAAAAAGARgm4AAAAAAMQa/wcL4l7b+PkEjwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1000x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "# Create a simulator for the Angle model (DDM with collapsing bounds)\n",
-    "angle_sim = Simulator(\"angle\")\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(10, 4))\n",
     "\n",
-    "# Run simulation with angle-specific parameters\n",
-    "angle_result = angle_sim.simulate(\n",
-    "    theta={\"v\": 0.5, \"a\": 1.5, \"z\": 0.5, \"t\": 0.3, \"theta\": 0.3},\n",
-    "    n_samples=500\n",
-    ")\n",
+    "axes[0].hist(rts, bins=30, color=\"C0\", alpha=0.85)\n",
+    "axes[0].set_title(\"Reaction times\")\n",
+    "axes[0].set_xlabel(\"RT\")\n",
+    "axes[0].set_ylabel(\"Count\")\n",
     "\n",
-    "print(\"Angle model parameters:\", angle_sim.config[\"params\"])\n",
-    "print(\"Sample RTs:\", angle_result[\"rts\"][:5])"
+    "labels, counts = np.unique(choices, return_counts=True)\n",
+    "axes[1].bar(labels.astype(str), counts / counts.sum(), color=\"C1\")\n",
+    "axes[1].set_title(\"Choice proportions\")\n",
+    "axes[1].set_xlabel(\"Choice\")\n",
+    "axes[1].set_ylabel(\"Proportion\")\n",
+    "\n",
+    "fig.tight_layout()"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "5676b76a",
    "metadata": {},
    "source": [
-    "The `Simulator` class also supports advanced features like custom boundary functions, custom drift functions, and even fully custom simulator implementations. For more details, see the [API documentation](../api/basic_simulators.md) and the [custom models tutorial](../core_tutorials/tutorial_custom_models.ipynb)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Using the Training Data Generators\n",
+    "## Functional API\n",
     "\n",
-    "The training data generators sit on top of the simulator function to turn raw simulations into usable training data for training machine learning algorithms aimed at posterior or likelihood amortization.\n",
-    "\n",
-    "We will use the `TrainingDataGenerator` class from `ssms.dataset_generators.lan_mlp`. Initializing the `TrainingDataGenerator` boils down to supplying a configuration dictionary.\n",
-    "\n",
-    "The `config` dictionary concerns choices as to what kind of training data one wants to generate, including the underlying generative *sequential sampling model*. \n",
-    "\n",
-    "We will consider a basic example here, concerning data generation to prepare for training [LANs](https://elifesciences.org/articles/65074).\n",
-    "\n",
-    "Let's start by peeking at an example `config`. The config is organized into sections: `pipeline`, `estimator`, `training`, `simulator`, `output`, and `model`."
+    "The original functional API remains available for short, one-off calls.\n",
+    "The class-based API above is more convenient when you will reuse a model\n",
+    "configuration or call the simulator repeatedly."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-12T01:46:35.904188Z",
-     "iopub.status.busy": "2026-07-12T01:46:35.904139Z",
-     "iopub.status.idle": "2026-07-12T01:46:35.905783Z",
-     "shell.execute_reply": "2026-07-12T01:46:35.905484Z"
-    }
-   },
+   "id": "5f64bf99",
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Config sections: dict_keys(['pipeline', 'estimator', 'training', 'simulator', 'output', 'model'])\n",
-      "\n",
-      "Pipeline settings: {'n_parameter_sets': 1000, 'n_parameter_sets_rejected': 100, 'n_subruns': 10, 'n_cpus': 'all', 'simulation_filters': {'mode': 20, 'choice_cnt': 0, 'mean_rt': 17, 'std': 0, 'mode_cnt_rel': 0.95}}\n",
-      "\n",
-      "Simulator settings: {'n_samples': 1000, 'max_t': 20.0, 'delta_t': 0.001}\n"
+      "Functional API keys: ['binned_128', 'binned_256', 'choice_p', 'choice_p_no_omission', 'choices', 'go_p', 'metadata', 'nogo_p', 'omission_p', 'rts']\n"
      ]
     }
    ],
    "source": [
-    "from ssms.config import get_default_generator_config\n",
+    "from ssms.basic_simulators.simulator import simulator\n",
     "\n",
-    "# Get generator config (defaults to \"lan\" approach, returns nested dictionary)\n",
-    "config = get_default_generator_config()\n",
-    "\n",
-    "# Show the nested structure\n",
-    "print(\"Config sections:\", config.keys())\n",
-    "print(\"\\nPipeline settings:\", config[\"pipeline\"])\n",
-    "print(\"\\nSimulator settings:\", {k: config[\"simulator\"][k] for k in [\"n_samples\", \"max_t\", \"delta_t\"]})"
+    "functional_out = simulator(\n",
+    "    model=\"ddm\", theta=theta, n_samples=1000, random_state=42\n",
+    ")\n",
+    "print(\"Functional API keys:\", sorted(functional_out))"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "1352dc31",
    "metadata": {},
    "source": [
-    "You usually have to make just few changes to this basic configuration dictionary.\n",
-    "An example below."
+    "## Try Another Model\n",
+    "\n",
+    "Other built-in models use the same simulator interface. The Angle model\n",
+    "below has an additional `theta` parameter for its collapsing boundary."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-12T01:46:35.906794Z",
-     "iopub.status.busy": "2026-07-12T01:46:35.906734Z",
-     "iopub.status.idle": "2026-07-12T01:46:35.908397Z",
-     "shell.execute_reply": "2026-07-12T01:46:35.907971Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from copy import deepcopy\n",
-    "\n",
-    "# Initialize the generator config (for MLP LANs)\n",
-    "generator_config = deepcopy(config)\n",
-    "\n",
-    "# Specify number of parameter sets to simulate\n",
-    "generator_config[\"pipeline\"][\"n_parameter_sets\"] = 100\n",
-    "\n",
-    "# Specify how many samples a simulation run should entail\n",
-    "generator_config[\"simulator\"][\"n_samples\"] = 1000"
-   ]
-  },
-  {
-   "cell_type": "markdown",
+   "id": "39e210d9",
    "metadata": {},
-   "source": [
-    "Now let's define our corresponding `model_config`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-12T01:46:35.909327Z",
-     "iopub.status.busy": "2026-07-12T01:46:35.909271Z",
-     "iopub.status.idle": "2026-07-12T01:46:35.910827Z",
-     "shell.execute_reply": "2026-07-12T01:46:35.910466Z"
-    }
-   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'name': 'angle', 'params': ['v', 'a', 'z', 't', 'theta'], 'param_bounds': [[-3.0, 0.3, 0.1, 0.001, -0.1], [3.0, 3.0, 0.9, 2.0, 1.3]], 'boundary_name': 'angle', 'boundary': <function angle at 0x120ac4cc0>, 'n_params': 5, 'default_params': [0.0, 1.0, 0.5, 0.001, 0.0], 'nchoices': 2, 'choices': [-1, 1], 'n_particles': 1, 'simulator': <cyfunction ddm_flexbound at 0x120fdf040>, 'parameter_transforms': {'sampling': [], 'simulation': []}, 'param_bounds_dict': {'v': (-3.0, 3.0), 'a': (0.3, 3.0), 'z': (0.1, 0.9), 't': (0.001, 2.0), 'theta': (-0.1, 1.3)}}\n"
+      "Model: angle\n",
+      "RT shape: (500, 1)\n",
+      "Choice shape: (500, 1)\n"
      ]
     }
    ],
    "source": [
-    "model_config = ssms.config.model_config[\"angle\"]\n",
-    "print(model_config)"
+    "angle_sim = Simulator(\"angle\")\n",
+    "angle_theta = {\n",
+    "    \"v\": 0.0,\n",
+    "    \"a\": 1.0,\n",
+    "    \"z\": 0.5,\n",
+    "    \"t\": 0.5,\n",
+    "    \"theta\": 0.3,\n",
+    "}\n",
+    "angle_out = angle_sim.simulate(\n",
+    "    theta=angle_theta, n_samples=500, random_state=42\n",
+    ")\n",
+    "print(\"Model:\", angle_sim.config[\"name\"])\n",
+    "print(\"RT shape:\", angle_out[\"rts\"].shape)\n",
+    "print(\"Choice shape:\", angle_out[\"choices\"].shape)"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "52aef2f7",
    "metadata": {},
    "source": [
-    "We are now ready to initialize a `TrainingDataGenerator`, after which we can generate training data using the `generate_data_training` function, which will use the hypercube defined by our parameter bounds from the `model_config` to uniformly generate parameter sets and corresponding simulated datasets."
+    "## Generate a Small Training Dataset\n",
+    "\n",
+    "`TrainingDataGenerator` combines parameter sampling and simulation into\n",
+    "the arrays used by likelihood approximation networks. The compact setup\n",
+    "below is designed to run quickly as a tutorial smoke test; increase the\n",
+    "sample counts for real training data.\n",
+    "\n",
+    "For the full configuration and production-oriented workflow, see the\n",
+    "[training data generator tutorial](../core_tutorials/tutorial_data_generators.ipynb)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-12T01:46:35.911634Z",
-     "iopub.status.busy": "2026-07-12T01:46:35.911588Z",
-     "iopub.status.idle": "2026-07-12T01:46:35.914713Z",
-     "shell.execute_reply": "2026-07-12T01:46:35.914386Z"
+   "execution_count": 10,
+   "id": "0070706c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output keys: ['binned_128', 'binned_256', 'cpn_data', 'cpn_labels', 'cpn_no_omission_data', 'cpn_no_omission_labels', 'generator_config', 'gonogo_data', 'gonogo_labels', 'lan_data', 'lan_labels', 'model_config', 'opn_data', 'opn_labels', 'theta']\n",
+      "LAN data shape: (100, 6)\n",
+      "LAN labels shape: (100,)\n"
+     ]
     }
-   },
-   "outputs": [],
+   ],
    "source": [
+    "from ssms.config import get_default_generator_config, model_config\n",
     "from ssms.dataset_generators.lan_mlp import TrainingDataGenerator\n",
     "\n",
-    "my_dataset_generator = TrainingDataGenerator(\n",
-    "    config=generator_config, model_config=model_config\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-12T01:46:35.915562Z",
-     "iopub.status.busy": "2026-07-12T01:46:35.915517Z",
-     "iopub.status.idle": "2026-07-12T01:46:38.052960Z",
-     "shell.execute_reply": "2026-07-12T01:46:38.052484Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "training_data = my_dataset_generator.generate_data_training(save=False)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`training_data` is a dictionary. The two keys used to train a [LAN](https://elifesciences.org/articles/65074) are:\n",
+    "generator_config = get_default_generator_config(model=\"ddm\")\n",
+    "generator_config[\"pipeline\"].update(\n",
+    "    {\n",
+    "        \"n_parameter_sets\": 2,\n",
+    "        \"n_parameter_sets_rejected\": 0,\n",
+    "        \"n_subruns\": 1,\n",
+    "        \"n_cpus\": 1,\n",
+    "    }\n",
+    ")\n",
+    "generator_config[\"training\"][\"n_samples_per_param\"] = 50\n",
+    "generator_config[\"simulator\"][\"n_samples\"] = 500\n",
     "\n",
-    "1. `lan_data` — the features: vectors of *model parameters* together with *rts* and *choices*.\n",
-    "2. `lan_labels` — the corresponding approximate log-likelihood values.\n",
+    "generator = TrainingDataGenerator(\n",
+    "    config=generator_config,\n",
+    "    model_config=model_config[\"ddm\"],\n",
+    ")\n",
+    "training_data = generator.generate_data_training(save=False)\n",
     "\n",
-    "Alongside these it also carries `theta` (the sampled parameter sets), auxiliary label arrays for related networks (`cpn_data`/`cpn_labels` for choice probabilities, `opn_data`/`opn_labels` for omissions, `gonogo_data`/`gonogo_labels`, and `cpn_no_omission_data`/`cpn_no_omission_labels`), binned RT histograms (`binned_128`, `binned_256`), and the `generator_config` and `model_config` used to produce it."
+    "print(\"Output keys:\", sorted(training_data))\n",
+    "print(\"LAN data shape:\", training_data[\"lan_data\"].shape)\n",
+    "print(\"LAN labels shape:\", training_data[\"lan_labels\"].shape)"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "6f596707",
    "metadata": {},
    "source": [
-    "You can now use this training data for your purposes. If you want to train [LANs](https://elifesciences.org/articles/65074) yourself, you might find the [LANfactory](https://github.com/AlexanderFengler/LANfactory) package helpful.\n",
+    "The returned dictionary also includes the sampled parameters and the\n",
+    "generator/model configurations. Set `save=True` and provide the output\n",
+    "settings from the full tutorial when you want to persist a dataset."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f755cde",
+   "metadata": {},
+   "source": [
+    "## Next Steps\n",
     "\n",
-    "You may also simply find the basic simulators provided with the **ssms** package useful, without any desire to use the outputs into training data for amortization purposes.\n",
-    "\n",
-    "##### END"
+    "- Browse the [simulator API](../api/basic_simulators.md) for available\n",
+    "  models and simulator arguments.\n",
+    "- Inspect the [configuration API](../api/config.md) for model and\n",
+    "  generator configuration helpers.\n",
+    "- Learn how to add a [custom model](../core_tutorials/tutorial_custom_models.ipynb).\n",
+    "- Use the [training data generator tutorial](../core_tutorials/tutorial_data_generators.ipynb)\n",
+    "  for larger datasets and persistence options."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -583,9 +488,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -40,8 +40,8 @@ Learn how to create custom parameter transformations for your models. This guide
 ## Quick Links
 
 - [Main README](../index.md)
-- [API Documentation](../api/)
-- [Tutorials](../core_tutorials/)
+- [API Documentation](../api/ssms.md)
+- [Tutorials](../core_tutorials/tutorial_capabilities.ipynb)
 - [GitHub Issues](https://github.com/lnccbrown/ssm-simulators/issues)
 - [Pull Requests](https://github.com/lnccbrown/ssm-simulators/pulls)
 

--- a/docs/contributing/add_models.md
+++ b/docs/contributing/add_models.md
@@ -4,15 +4,15 @@ This guide helps academic researchers contribute new sequential sampling models 
 
 ## Table of Contents
 
-1. [Introduction & Prerequisites](#1-introduction--prerequisites)
+1. [Introduction & Prerequisites](#1-introduction-prerequisites)
 2. [Understanding the Architecture](#2-understanding-the-architecture)
 3. [Level 1: Boundary/Drift Variants](#3-level-1-contributing-boundarydrift-variants)
 4. [Level 2: Python Simulators](#4-level-2-contributing-python-simulators)
 5. [Level 3: Cython Simulators](#5-level-3-contributing-cython-simulators)
 6. [Testing Your Contribution](#6-testing-your-contribution)
 7. [Documentation Requirements](#7-documentation-requirements)
-8. [Submitting Your PR](#8-submitting-your-pr)
-9. [Troubleshooting & FAQ](#9-troubleshooting--faq)
+8. [Creating Your Pull Request](#creating-your-pull-request)
+9. [Getting Help](#getting-help)
 
 ---
 
@@ -65,7 +65,7 @@ START: What do you want to contribute?
 **Optional**:
 - Cython knowledge (Level 3 only)
 - Experience with numerical computing
-- Familiarity with the package (see [tutorials](../../notebooks/))
+- Familiarity with the package (see the [package overview tutorial](../core_tutorials/tutorial_capabilities.ipynb))
 
 ### Development Setup
 
@@ -1373,8 +1373,8 @@ If you're stuck:
    - Complex: `race.py`, `lca.py`
 
 2. **Read documentation**:
-   - [Core Tutorials](../core_tutorials/)
-   - [API Documentation](../api/)
+   - [Core Tutorials](../core_tutorials/tutorial_capabilities.ipynb)
+   - [API Documentation](../api/ssms.md)
 
 3. **GitHub issues**: Search for similar problems
    - [Known issues](https://github.com/lnccbrown/ssm-simulators/issues)
@@ -1386,7 +1386,7 @@ If you're stuck:
 
 ### Resources
 
-- [Interactive Tutorials](../../notebooks/): Learn by doing
-- [API Reference](../api/): Complete API documentation
+- [Interactive Tutorials](../basic_tutorial/basic_tutorial.ipynb): Learn by doing
+- [API Reference](../api/ssms.md): Complete API documentation
 - [GitHub Issues](https://github.com/lnccbrown/ssm-simulators/issues): Questions and bugs
 - [Discussions](https://github.com/lnccbrown/ssm-simulators/discussions)

--- a/docs/contributing/add_parameter_adapters.md
+++ b/docs/contributing/add_parameter_adapters.md
@@ -280,6 +280,6 @@ The key insight is that **all parameter transforms are defined directly in the m
 ## Resources
 
 - [Adding Models Tutorial](add_models.md): How to contribute new models
-- [API Reference](../api/): Complete API documentation
+- [API Reference](../api/ssms.md): Complete API documentation
 - Built-in simulation transforms: `ssms/basic_simulators/parameter_adapters/`
 - Built-in sampling transforms: `ssms/transforms/sampling/`

--- a/docs/core_tutorials/kde_class.ipynb
+++ b/docs/core_tutorials/kde_class.ipynb
@@ -15,8 +15,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open with marimo](https://marimo.io/shield.svg)](https://molab.marimo.io/github/lnccbrown/ssm-simulators/blob/first-marimo-tutorial/docs/tutorials/kde_class.ipynb)\n",
-    "[![Open with colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lnccbrown/ssm-simulators/blob/first-marimo-tutorial/docs/tutorials/kde_class.ipynb)"
+    "[![Open with marimo](https://marimo.io/shield.svg)](https://molab.marimo.io/github/lnccbrown/ssm-simulators/blob/main/docs/core_tutorials/kde_class.ipynb)\n",
+    "[![Open with colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lnccbrown/ssm-simulators/blob/main/docs/core_tutorials/kde_class.ipynb)"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ssm-simulators"
-version = "0.13.1"
+version = "0.13.2"
 description = "SSMS is a package collecting simulators and training data generators for cognitive science, neuroscience, and approximate bayesian computation"
 authors = [
     { name = "Alexander Fengler", email = "alexander_fengler@brown.edu" },


### PR DESCRIPTION
## Summary

Prepare `ssm-simulators` `0.13.2`.

Release range: `v0.13.1..HEAD`

Highlights:
- Adds canonical RLSSM presets for Rescorla-Wagner DDM, angle, Weibull, and
  dual-alpha angle models.
- Adds response-only inverse-temperature softmax presets for two-, three-, and
  four-choice tasks, including a dual-alpha two-choice variant.
- Adds the four-choice `race_no_bias_angle_4` RLSSM preset and documents its
  learning-to-race scaling contract.
- Updates RLSSM documentation and tutorials for the expanded preset surface,
  choice-only response contracts, and HSSM handoff behavior.
- Repairs stale hosted-notebook URLs, contributing-guide TOC anchors, and
  directory links that MkDocs could not resolve.
- Rebuilds the basic tutorial around the class-based `Simulator` API, with
  reproducibility checks, a reaction-time/choice diagnostic, a functional API
  compatibility example, and a compact `TrainingDataGenerator` tour.
- Extends RLSSM tests for preset metadata, learning behavior, response-only
  softmax models, and HSSM compatibility contracts.

## Release Scope

- Version bump: `0.13.1` -> `0.13.2`
- Python support unchanged: `>=3.12,<3.15`
- No dependency pin changes required for HSSM or LANfactory.
- No tag or package publication in this PR.
- No conda-forge feedstock update in this PR.

## Validation

- [x] `uv sync --all-groups`
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] Package-source mypy: `mypy ssms --no-strict-optional --ignore-missing-imports`
- [x] RL tests: `pytest tests/rl --no-cov -v` (294 passed)
- [x] Full tests: `pytest tests/ --no-cov` (929 passed, 194 skipped)
- [x] `mkdocs build` (build succeeds; existing non-link warnings remain)
- [x] Local docs link audit: 51 local targets/fragments resolve.
- [x] External docs URL audit: 34 URLs returned HTTP 200; the remaining DOI
  resolves through Crossref and bioRxiv returns a Cloudflare challenge to
  automated clients.
- [x] Targeted notebook test: `pytest tests/test_notebooks.py --run-notebooks
  -k basic_tutorial --no-cov -v` (1 passed with the release venv on `PATH`).
- [x] Basic tutorial JSON validation and `git diff --check`.
- [x] Local docs link audit: 54 local targets/fragments resolve after the
  tutorial rewrite.
- [x] Full `mypy . --no-strict-optional --ignore-missing-imports` remains
  blocked by two pre-existing test annotation errors.
- [x] `mkdocs build --strict` remains blocked by existing API autorefs,
  generated HTML, and one unlisted contributing README warning.
- [x] GitHub PR checks pass, including wheel and sdist build checks.

## Post-Merge Release Steps

After this PR merges:
1. Create tag `v0.13.2` on the merge commit.
2. Publish the GitHub release so the existing release workflow builds and
   uploads the package artifacts.
3. Verify the published package before updating the conda-forge feedstock.
