### PR TITLE
Scheduled drift detection: weekly full-suite re-run against fresh resolves

### DIFF
--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -17,16 +17,27 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   tests:
+    # Only `report` needs issue-write; the token that runs freshly-resolved
+    # third-party test code should not carry it.
+    permissions:
+      contents: read
     uses: ./.github/workflows/run_tests.yml
 
   report:
     needs: [tests]
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    # One issue reconciler at a time: the read at `gh issue list` and the write
+    # below are not atomic, so an overlapping dispatch could file a duplicate.
+    concurrency:
+      group: drift-issue-${{ github.repository }}
+      cancel-in-progress: false
     steps:
       - name: Create, update, or close the deduped drift issue
         env:
@@ -51,10 +62,19 @@ jobs:
             --state open --search "in:body \"$KEY\"" \
             --json number --jq '.[0].number // empty')
 
+          # Only a genuine success closes the issue. `report` runs under
+          # `if: always()`, which includes cancellation, and a cancelled or
+          # never-started test job is no evidence of health — treating it as
+          # green would silently retire a real drift issue.
           if [ -z "$FAILED_JOBS" ]; then
-            if [ -n "$EXISTING" ]; then
-              gh issue close "$EXISTING" --repo "$GITHUB_REPOSITORY" \
-                --comment "Scheduled drift checks green again: $RUN_URL"
+            if [ "$RESULT_TESTS" = "success" ]; then
+              if [ -n "$EXISTING" ]; then
+                gh issue close "$EXISTING" --repo "$GITHUB_REPOSITORY" \
+                  --comment "Scheduled drift checks green again: $RUN_URL"
+              fi
+            else
+              echo "::notice::Inconclusive run (tests: $RESULT_TESTS) —" \
+                "drift issue state left unchanged."
             fi
             exit 0
           fi

--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -1,0 +1,78 @@
+name: Drift
+
+# Scheduled drift detection: re-run the full test workflow (unit matrix,
+# GSL/OpenMP multithreading, notebooks) against a fresh dependency resolve of
+# an unchanged main. No lockfile is committed, so a red run here means an
+# upstream or toolchain release broke us — before any PR trips over it.
+# Failures file ONE deduped `drift`-labeled issue; green runs close it.
+on:
+  schedule:
+    - cron: "10 5 * * 1" # weekly
+  workflow_dispatch:
+    inputs:
+      force_fail:
+        description: "Exercise the drift-issue path without a real failure"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  tests:
+    uses: ./.github/workflows/run_tests.yml
+
+  report:
+    needs: [tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create, update, or close the deduped drift issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESULT_TESTS: ${{ needs.tests.result }}
+          FORCE_FAIL: ${{ inputs.force_fail }}
+        run: |
+          set -euo pipefail
+          KEY="drift-key: ssm-simulators-scheduled"
+          TITLE="drift: ssm-simulators scheduled checks failing"
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+          FAILED_JOBS=""
+          if [ "$RESULT_TESTS" = "failure" ]; then
+            FAILED_JOBS=" tests"
+          fi
+          if [ "$FORCE_FAIL" = "true" ]; then
+            FAILED_JOBS="$FAILED_JOBS (force_fail rehearsal)"
+          fi
+
+          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --label drift \
+            --state open --search "in:body \"$KEY\"" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -z "$FAILED_JOBS" ]; then
+            if [ -n "$EXISTING" ]; then
+              gh issue close "$EXISTING" --repo "$GITHUB_REPOSITORY" \
+                --comment "Scheduled drift checks green again: $RUN_URL"
+            fi
+            exit 0
+          fi
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" \
+              --body "Still failing (${FAILED_JOBS# }): $RUN_URL"
+          else
+            gh label create drift --repo "$GITHUB_REPOSITORY" \
+              --description "scheduled drift detection failure" \
+              --force 2>/dev/null || true
+            BODY=$(printf '%s\n' \
+              "<!-- $KEY -->" \
+              "Scheduled drift run failed in:${FAILED_JOBS}" \
+              "Run: $RUN_URL" \
+              "" \
+              "This re-runs the existing test workflow against a fresh dependency resolve of an unchanged main — a failure usually means an upstream or toolchain release, not a code change." \
+              "Triage via the spine's audit-drift skill.")
+            gh issue create --repo "$GITHUB_REPOSITORY" --label drift \
+              --title "$TITLE" --body "$BODY"
+          fi

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,6 +2,7 @@ name: Run tests
 
 on:
   pull_request:
+  workflow_call: # Called by drift.yml (scheduled drift detection)
   push:
     branches:
       - main # Tracking coverage for main branch as well
@@ -28,7 +29,7 @@ jobs:
         with:
           version: "latest"
           enable-cache: true
-          cache-dependency-glob: "pyproject.toml pdm.lock"
+          cache-dependency-glob: "pyproject.toml" # (a stale pdm.lock reference sat here; that file never existed)
 
       - name: Install package
         run: uv sync --all-groups
@@ -73,7 +74,7 @@ jobs:
         with:
           version: "latest"
           enable-cache: true
-          cache-dependency-glob: "pyproject.toml pdm.lock"
+          cache-dependency-glob: "pyproject.toml" # (a stale pdm.lock reference sat here; that file never existed)
 
       - name: Install package (with GSL + OpenMP)
         run: uv sync --all-groups
@@ -112,7 +113,7 @@ jobs:
         with:
           version: "latest"
           enable-cache: true
-          cache-dependency-glob: "pyproject.toml pdm.lock"
+          cache-dependency-glob: "pyproject.toml" # (a stale pdm.lock reference sat here; that file never existed)
 
       - name: Install package (with notebook deps)
         run: uv sync --all-groups


### PR DESCRIPTION
Part of the ecosystem self-healing rollout (aggregation layer: lnccbrown/HSSMSpine#35; HSSM sibling: lnccbrown/HSSM#1143).

- new `drift.yml`: weekly scheduled re-run of the full existing test workflow via `workflow_call`, against a fresh PyPI resolve of unchanged main — the detector for upstream/toolchain drift (the ruff 0.16 breakage, #317, sat undetected for weeks because main's CI only runs on push)
- failures create/update ONE deduped `drift`-labeled issue; green runs close it; `force_fail` dispatch input rehearses the path
- riding along: `workflow_call:` on `run_tests.yml`; the setup-uv cache glob referenced a `pdm.lock` that never existed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added scheduled and manually triggered automated checks to monitor project health.
  - Failed checks now create or update a single tracked issue, while confirmed recovery automatically closes it.
  - Added a manual testing option for validating failure reporting.
  - Inconclusive or cancelled checks no longer change issue status.
  - Improved test workflow reuse and corrected dependency caching configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->