### PR TITLE
Make every datagen MLflow run self-describing

### DIFF
--- a/ssms/cli/generate.py
+++ b/ssms/cli/generate.py
@@ -44,6 +44,12 @@ def make_data_generator_configs(
 
     model_config.update(model_config_arg_dict)
 
+    # Persist the approach that selected this config template. Without this the
+    # information exists only at call time — it never reaches the generated
+    # training-data pickles (which embed data_config as `generator_config`) or
+    # any MLflow record built from them.
+    data_config["generator_approach"] = generator_approach
+
     config_dict = {"model_config": model_config, "data_config": data_config}
 
     if save_name:
@@ -379,6 +385,76 @@ def generate_data(  # pragma: no cover
     return newly_generated_files, output_folder
 
 
+def parse_mlflow_tags(raw_tags: list[str]) -> dict[str, str]:
+    """Parse repeatable ``--mlflow-tag KEY=VALUE`` options into a dict.
+
+    Raises:
+        typer.BadParameter: if an entry has no ``=`` or an empty key.
+    """
+    tags: dict[str, str] = {}
+    for raw in raw_tags:
+        key, sep, value = raw.partition("=")
+        if not sep or not key:
+            raise typer.BadParameter(
+                f"--mlflow-tag expects KEY=VALUE, got {raw!r}",
+                param_hint="--mlflow-tag",
+            )
+        tags[key] = value
+    return tags
+
+
+def log_run_identity(  # pragma: no cover
+    config_dict: dict,
+    config_path: Path | None,
+    n_files: int,
+    extra_tags: dict[str, str],
+    logger: logging.Logger,
+) -> None:
+    """Make the MLflow run self-describing.
+
+    Downstream consumers (LANfactory training, the network registry) resolve
+    "which model was this data generated for" from these params/tags rather
+    than from experiment-name conventions, which only hold for orchestrated
+    runs. Schema documented in HSSMSpine `_docs/mlflow-schema.md`.
+    """
+    import hashlib
+    from importlib.metadata import PackageNotFoundError, version
+
+    import mlflow
+
+    data_config = config_dict["data_config"]
+    params: dict[str, Any] = {
+        "model": data_config.get("model"),
+        "generator_approach": data_config.get("generator_approach"),
+        "n_files": n_files,
+    }
+
+    if config_path is not None and Path(config_path).is_file():
+        params["config_sha256"] = hashlib.sha256(
+            Path(config_path).read_bytes()
+        ).hexdigest()
+
+    try:
+        params["ssm_simulators_version"] = version("ssm-simulators")
+    except PackageNotFoundError:  # editable/source checkouts without metadata
+        logger.debug("ssm-simulators version metadata unavailable; skipping param")
+
+    mlflow.log_params(params)
+
+    tags = {"schema_version": "1", "phase": "datagen"}
+    for env_key, tag in (
+        ("SLURM_JOB_ID", "slurm_job_id"),
+        ("SLURM_ARRAY_JOB_ID", "slurm_array_job_id"),
+        ("SLURM_ARRAY_TASK_ID", "slurm_array_task_id"),
+    ):
+        if os.getenv(env_key):
+            tags[tag] = os.environ[env_key]
+    # Caller-supplied tags (e.g. generation_batch_id from the orchestrator)
+    # win over the defaults on key collision.
+    tags.update(extra_tags)
+    mlflow.set_tags(tags)
+
+
 def log_to_mlflow(  # pragma: no cover
     config_dict: dict,
     newly_generated_files: list[Path],
@@ -475,6 +551,12 @@ def main(  # pragma: no cover
         help="Root directory for MLflow artifacts. "
         "Defaults to MLFLOW_ARTIFACT_LOCATION env var, then './mlruns'.",
     ),
+    mlflow_tag: list[str] = typer.Option(
+        [],
+        "--mlflow-tag",
+        help="Extra MLflow tag as KEY=VALUE. Repeatable. Lets an orchestrator "
+        "stamp e.g. generation_batch_id without this CLI knowing about it.",
+    ),
     estimator_type: str = typer.Option(
         None,
         "--estimator-type",
@@ -512,6 +594,10 @@ def main(  # pragma: no cover
         logger,
     )
 
+    # Parse tags before any work so a malformed --mlflow-tag fails fast,
+    # even when MLflow itself is inactive.
+    extra_tags = parse_mlflow_tags(mlflow_tag)
+
     # Load and prepare configuration
     config_dict = load_config(config_path, output, estimator_type, logger)
 
@@ -519,6 +605,7 @@ def main(  # pragma: no cover
     if mlflow_active:
         import mlflow
 
+        log_run_identity(config_dict, config_path, n_files, extra_tags, logger)
         mlflow.log_params(
             {f"data_{k}": v for k, v in config_dict["data_config"].items()}
         )

--- a/ssms/cli/generate.py
+++ b/ssms/cli/generate.py
@@ -259,23 +259,40 @@ def load_config(  # pragma: no cover
     output: Path,
     estimator_type: str,
     logger: logging.Logger,
-) -> dict:
+) -> tuple[dict, str | None]:
     """
     Load and prepare the generator configuration.
 
     Returns:
-        dict: Configuration dictionary with 'data_config' and 'model_config' keys.
+        tuple: (config_dict with 'data_config'/'model_config' keys,
+        sha256 hex digest of the driving YAML — including the packaged
+        default when no --config-path was given — or None if unreadable).
+        The hash is computed here because the packaged default only exists
+        on disk inside the ``as_file`` context.
     """
+    import hashlib
+
+    def _sha(p: Path) -> str | None:
+        try:
+            return hashlib.sha256(Path(p).read_bytes()).hexdigest()
+        except OSError:
+            return None
+
     if config_path is None:
         logger.warning("No config path provided, using default configuration.")
         with as_file(
             files("ssms.cli") / "config_data_generation.yaml"
         ) as default_config:
             config_path = default_config
-
-    config_dict = collect_data_generator_config(
-        yaml_config_path=config_path, base_path=output
-    )
+            config_sha256 = _sha(config_path)
+            config_dict = collect_data_generator_config(
+                yaml_config_path=config_path, base_path=output
+            )
+    else:
+        config_sha256 = _sha(config_path)
+        config_dict = collect_data_generator_config(
+            yaml_config_path=config_path, base_path=output
+        )
 
     # Override estimator_type if specified via CLI
     if estimator_type is not None:
@@ -288,7 +305,7 @@ def load_config(  # pragma: no cover
     logger.debug("MODEL CONFIG")
     logger.debug(pformat(config_dict["model_config"]))
 
-    return config_dict
+    return config_dict, config_sha256
 
 
 def create_estimator(  # pragma: no cover
@@ -385,11 +402,17 @@ def generate_data(  # pragma: no cover
     return newly_generated_files, output_folder
 
 
+# Tags the schema owns; user tags must not overwrite them or downstream
+# consumers filtering on them would silently miss the run.
+RESERVED_MLFLOW_TAGS = frozenset({"schema_version", "phase"})
+
+
 def parse_mlflow_tags(raw_tags: list[str]) -> dict[str, str]:
     """Parse repeatable ``--mlflow-tag KEY=VALUE`` options into a dict.
 
     Raises:
-        typer.BadParameter: if an entry has no ``=`` or an empty key.
+        typer.BadParameter: if an entry has no ``=``, an empty key, or a
+            reserved schema tag key.
     """
     tags: dict[str, str] = {}
     for raw in raw_tags:
@@ -399,14 +422,20 @@ def parse_mlflow_tags(raw_tags: list[str]) -> dict[str, str]:
                 f"--mlflow-tag expects KEY=VALUE, got {raw!r}",
                 param_hint="--mlflow-tag",
             )
+        if key in RESERVED_MLFLOW_TAGS:
+            raise typer.BadParameter(
+                f"--mlflow-tag may not override the reserved schema tag {key!r}",
+                param_hint="--mlflow-tag",
+            )
         tags[key] = value
     return tags
 
 
 def log_run_identity(  # pragma: no cover
     config_dict: dict,
-    config_path: Path | None,
+    config_sha256: str | None,
     n_files: int,
+    dry_run: bool,
     extra_tags: dict[str, str],
     logger: logging.Logger,
 ) -> None:
@@ -416,8 +445,10 @@ def log_run_identity(  # pragma: no cover
     "which model was this data generated for" from these params/tags rather
     than from experiment-name conventions, which only hold for orchestrated
     runs. Schema documented in HSSMSpine `_docs/mlflow-schema.md`.
+
+    Dry runs are tagged ``phase=datagen_dry_run`` so schema-filtered consumers
+    (``tags.phase = 'datagen'``) never select a run that produced no data.
     """
-    import hashlib
     from importlib.metadata import PackageNotFoundError, version
 
     import mlflow
@@ -429,10 +460,8 @@ def log_run_identity(  # pragma: no cover
         "n_files": n_files,
     }
 
-    if config_path is not None and Path(config_path).is_file():
-        params["config_sha256"] = hashlib.sha256(
-            Path(config_path).read_bytes()
-        ).hexdigest()
+    if config_sha256 is not None:
+        params["config_sha256"] = config_sha256
 
     try:
         params["ssm_simulators_version"] = version("ssm-simulators")
@@ -441,7 +470,10 @@ def log_run_identity(  # pragma: no cover
 
     mlflow.log_params(params)
 
-    tags = {"schema_version": "1", "phase": "datagen"}
+    tags = {
+        "schema_version": "1",
+        "phase": "datagen_dry_run" if dry_run else "datagen",
+    }
     for env_key, tag in (
         ("SLURM_JOB_ID", "slurm_job_id"),
         ("SLURM_ARRAY_JOB_ID", "slurm_array_job_id"),
@@ -449,8 +481,9 @@ def log_run_identity(  # pragma: no cover
     ):
         if os.getenv(env_key):
             tags[tag] = os.environ[env_key]
-    # Caller-supplied tags (e.g. generation_batch_id from the orchestrator)
-    # win over the defaults on key collision.
+    # Caller-supplied tags (e.g. generation_batch_id from the orchestrator).
+    # Reserved schema tags are rejected at parse time, so these cannot
+    # overwrite schema_version/phase.
     tags.update(extra_tags)
     mlflow.set_tags(tags)
 
@@ -585,6 +618,10 @@ def main(  # pragma: no cover
     )
     logger = logging.getLogger(__name__)
 
+    # Parse tags before ANY MLflow work so a malformed --mlflow-tag fails
+    # fast without leaving a junk empty run in the tracking store.
+    extra_tags = parse_mlflow_tags(mlflow_tag)
+
     # Setup MLflow
     mlflow_active = setup_mlflow(
         mlflow_run_name,
@@ -594,18 +631,18 @@ def main(  # pragma: no cover
         logger,
     )
 
-    # Parse tags before any work so a malformed --mlflow-tag fails fast,
-    # even when MLflow itself is inactive.
-    extra_tags = parse_mlflow_tags(mlflow_tag)
-
     # Load and prepare configuration
-    config_dict = load_config(config_path, output, estimator_type, logger)
+    config_dict, config_sha256 = load_config(
+        config_path, output, estimator_type, logger
+    )
 
     # Log initial config to MLflow
     if mlflow_active:
         import mlflow
 
-        log_run_identity(config_dict, config_path, n_files, extra_tags, logger)
+        log_run_identity(
+            config_dict, config_sha256, n_files, dry_run, extra_tags, logger
+        )
         mlflow.log_params(
             {f"data_{k}": v for k, v in config_dict["data_config"].items()}
         )

--- a/tests/test_generate_cli.py
+++ b/tests/test_generate_cli.py
@@ -168,3 +168,45 @@ def test_collect_config_estimator_type_case_insensitive(tmp_path):
 
 # TODO: test app object and CLI commands with --estimator-type flag.
 # This requires using typer.testing.CliRunner, which is harder to do than with argparse
+
+
+def test_generator_approach_persisted_in_data_config():
+    """The selecting approach must survive into data_config (provenance)."""
+    from ssms.cli.generate import make_data_generator_configs
+
+    config = make_data_generator_configs(model="ddm", generator_approach="lan")
+    assert config["data_config"]["generator_approach"] == "lan"
+
+    config_re = make_data_generator_configs(
+        model="ddm", generator_approach="ratio_estimator"
+    )
+    assert config_re["data_config"]["generator_approach"] == "ratio_estimator"
+
+
+class TestParseMlflowTags:
+    def test_single_and_multiple_tags(self):
+        from ssms.cli.generate import parse_mlflow_tags
+
+        assert parse_mlflow_tags(["a=1"]) == {"a": "1"}
+        assert parse_mlflow_tags(["a=1", "b=x=y"]) == {"a": "1", "b": "x=y"}
+
+    def test_empty_value_allowed(self):
+        from ssms.cli.generate import parse_mlflow_tags
+
+        assert parse_mlflow_tags(["flag="]) == {"flag": ""}
+
+    def test_missing_separator_rejected(self):
+        import typer
+
+        from ssms.cli.generate import parse_mlflow_tags
+
+        with pytest.raises(typer.BadParameter):
+            parse_mlflow_tags(["notagvalue"])
+
+    def test_empty_key_rejected(self):
+        import typer
+
+        from ssms.cli.generate import parse_mlflow_tags
+
+        with pytest.raises(typer.BadParameter):
+            parse_mlflow_tags(["=value"])

--- a/tests/test_generate_cli.py
+++ b/tests/test_generate_cli.py
@@ -210,3 +210,12 @@ class TestParseMlflowTags:
 
         with pytest.raises(typer.BadParameter):
             parse_mlflow_tags(["=value"])
+
+    def test_reserved_schema_tags_rejected(self):
+        import typer
+
+        from ssms.cli.generate import parse_mlflow_tags
+
+        for reserved in ("schema_version=2", "phase=custom"):
+            with pytest.raises(typer.BadParameter):
+                parse_mlflow_tags([reserved])

--- a/tests/test_mlflow_integration.py
+++ b/tests/test_mlflow_integration.py
@@ -422,3 +422,96 @@ def test_full_cli_workflow_simulation(tmp_path):
     artifacts = client.list_artifacts(worker_runs.iloc[0]["run_id"])
     artifact_names = [a.path for a in artifacts]
     assert "data_config.json" in artifact_names
+
+
+class TestRunIdentity:
+    """PR feat/mlflow-run-identity: every datagen run must be self-describing."""
+
+    def _run_identity(
+        self, test_mlflow_dir, tmp_path, monkeypatch=None, extra_tags=None
+    ):
+        import logging
+
+        from ssms.cli.generate import log_run_identity
+
+        config_yaml = tmp_path / "cfg.yaml"
+        config_yaml.write_text("MODEL: ddm\nGENERATOR_APPROACH: lan\n")
+
+        config = make_data_generator_configs(model="ddm", generator_approach="lan")
+
+        mlflow.set_experiment("identity-test")
+        with mlflow.start_run() as run:
+            log_run_identity(
+                config_dict=config,
+                config_path=config_yaml,
+                n_files=7,
+                extra_tags=extra_tags or {},
+                logger=logging.getLogger("test"),
+            )
+            run_id = run.info.run_id
+
+        client = mlflow.tracking.MlflowClient()
+        return client.get_run(run_id)
+
+    def test_identity_params_logged(self, test_mlflow_dir, tmp_path):
+        run = self._run_identity(test_mlflow_dir, tmp_path)
+        params = run.data.params
+
+        assert params["model"] == "ddm"
+        assert params["generator_approach"] == "lan"
+        assert params["n_files"] == "7"
+        # sha256 of the config file bytes, hex-encoded
+        assert len(params["config_sha256"]) == 64
+        assert "ssm_simulators_version" in params
+
+    def test_schema_tags_logged(self, test_mlflow_dir, tmp_path):
+        run = self._run_identity(test_mlflow_dir, tmp_path)
+        tags = run.data.tags
+
+        assert tags["schema_version"] == "1"
+        assert tags["phase"] == "datagen"
+
+    def test_slurm_tags_from_env(self, test_mlflow_dir, tmp_path, monkeypatch):
+        monkeypatch.setenv("SLURM_JOB_ID", "12345")
+        monkeypatch.setenv("SLURM_ARRAY_TASK_ID", "3")
+        monkeypatch.delenv("SLURM_ARRAY_JOB_ID", raising=False)
+
+        run = self._run_identity(test_mlflow_dir, tmp_path)
+        tags = run.data.tags
+
+        assert tags["slurm_job_id"] == "12345"
+        assert tags["slurm_array_task_id"] == "3"
+        assert "slurm_array_job_id" not in tags
+
+    def test_extra_tags_win_on_collision(self, test_mlflow_dir, tmp_path):
+        run = self._run_identity(
+            test_mlflow_dir,
+            tmp_path,
+            extra_tags={"generation_batch_id": "batch-42", "phase": "override"},
+        )
+        tags = run.data.tags
+
+        assert tags["generation_batch_id"] == "batch-42"
+        assert tags["phase"] == "override"
+
+    def test_missing_config_file_skips_sha(self, test_mlflow_dir, tmp_path):
+        import logging
+
+        from ssms.cli.generate import log_run_identity
+
+        config = make_data_generator_configs(model="ddm", generator_approach="lan")
+
+        mlflow.set_experiment("identity-test-nosha")
+        with mlflow.start_run() as run:
+            log_run_identity(
+                config_dict=config,
+                config_path=None,
+                n_files=1,
+                extra_tags={},
+                logger=logging.getLogger("test"),
+            )
+            run_id = run.info.run_id
+
+        client = mlflow.tracking.MlflowClient()
+        params = client.get_run(run_id).data.params
+        assert "config_sha256" not in params

--- a/tests/test_mlflow_integration.py
+++ b/tests/test_mlflow_integration.py
@@ -439,12 +439,15 @@ class TestRunIdentity:
 
         config = make_data_generator_configs(model="ddm", generator_approach="lan")
 
+        import hashlib
+
         mlflow.set_experiment("identity-test")
         with mlflow.start_run() as run:
             log_run_identity(
                 config_dict=config,
-                config_path=config_yaml,
+                config_sha256=hashlib.sha256(config_yaml.read_bytes()).hexdigest(),
                 n_files=7,
+                dry_run=False,
                 extra_tags=extra_tags or {},
                 logger=logging.getLogger("test"),
             )
@@ -483,18 +486,40 @@ class TestRunIdentity:
         assert tags["slurm_array_task_id"] == "3"
         assert "slurm_array_job_id" not in tags
 
-    def test_extra_tags_win_on_collision(self, test_mlflow_dir, tmp_path):
+    def test_extra_tags_are_applied(self, test_mlflow_dir, tmp_path):
         run = self._run_identity(
             test_mlflow_dir,
             tmp_path,
-            extra_tags={"generation_batch_id": "batch-42", "phase": "override"},
+            extra_tags={"generation_batch_id": "batch-42"},
         )
         tags = run.data.tags
 
         assert tags["generation_batch_id"] == "batch-42"
-        assert tags["phase"] == "override"
+        # schema tags survive alongside caller tags
+        assert tags["phase"] == "datagen"
 
-    def test_missing_config_file_skips_sha(self, test_mlflow_dir, tmp_path):
+    def test_dry_run_gets_distinct_phase_tag(self, test_mlflow_dir, tmp_path):
+        import logging
+
+        from ssms.cli.generate import log_run_identity
+
+        config = make_data_generator_configs(model="ddm", generator_approach="lan")
+        mlflow.set_experiment("identity-test-dry")
+        with mlflow.start_run() as run:
+            log_run_identity(
+                config_dict=config,
+                config_sha256=None,
+                n_files=5,
+                dry_run=True,
+                extra_tags={},
+                logger=logging.getLogger("test"),
+            )
+            run_id = run.info.run_id
+
+        tags = mlflow.tracking.MlflowClient().get_run(run_id).data.tags
+        assert tags["phase"] == "datagen_dry_run"
+
+    def test_missing_config_sha_skips_param(self, test_mlflow_dir, tmp_path):
         import logging
 
         from ssms.cli.generate import log_run_identity
@@ -505,8 +530,9 @@ class TestRunIdentity:
         with mlflow.start_run() as run:
             log_run_identity(
                 config_dict=config,
-                config_path=None,
+                config_sha256=None,
                 n_files=1,
+                dry_run=False,
                 extra_tags={},
                 logger=logging.getLogger("test"),
             )


### PR DESCRIPTION
## What

First PR of the HSSM ecosystem's "MLflow as database of record" workstream (PR-0.1 of the plan coordinated in HSSMSpine). Every `generate` invocation now logs enough identity onto its MLflow run that a catalog can answer "what data is this?" without unpickling artifacts or decoding experiment-name conventions:

- **Params** (immutable facts): `model`, `generator_approach`, `n_files`, `config_sha256`, `ssm_simulators_version`, `data_output_folder`
- **Tags** (per-invocation): `schema_version=1`, `phase=datagen` (or `datagen_dry_run`), SLURM ids from env when present
- New repeatable `--mlflow-tag KEY=VALUE` option so an orchestrator can stamp batch-level tags (e.g. a generation-batch id) without this repo knowing about them; reserved keys (`schema_version`, `phase`) are rejected at parse time, and parsing happens **before** MLflow setup so a malformed tag can't leave a junk run behind
- `generator_approach` is now persisted into `data_config` inside the training-data pickles, so downstream consumers (LANfactory) see provenance too
- `config_sha256` is computed inside `load_config` (the packaged default config only exists inside the `as_file` context, so hashing outside it was impossible)

## Ecosystem impact

Downstream: LANfactory's training runs (companion PR lnccbrown/LANfactory) log a matching schema so datagen ↔ training runs can be joined; LAN_pipeline_minimal will consume `--mlflow-tag` for batch stamping. No API breaks — all changes are additive.

## Review provenance

This diff went through an adversarial multi-agent review before opening (12 findings across the three Phase-0 branches, all addressed or empirically refuted). Findings fixed here: junk-run-on-malformed-tag, reserved-tag overwrite, dry-run phase pollution, missing sha for the packaged default config.

## Commands run

```
uv run pytest tests/   # 1022 passed
uv run ruff check . && uv run ruff format --check .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)