### PR TITLE
docs: adopt the shared ecosystem brand bundle (phase 1)

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,7 +1,9 @@
 {#- HSSM ecosystem shared announcement banner.
-    SOURCE OF TRUTH: HSSMSpine/docs-brand/main.html — synced by
-    scripts/sync_docs_brand.py; do not edit the vendored copies.
-    Repo-agnostic: all links derive from config.repo_url. -#}
+    VENDORED COPY — source of truth: https://github.com/lnccbrown/HSSMSpine
+    (docs-brand/main.html). Edit there and re-sync; local edits will be
+    flagged as drift. Repo-agnostic: the release link derives from
+    config.repo_url; questions route to the ecosystem's shared forum
+    (HSSM Discussions) by design. -#}
 {% extends "base.html" %}
 {% block announce %}
 <span class="show-on-small right-margin">

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,5 +1,8 @@
+{#- HSSM ecosystem shared announcement banner.
+    SOURCE OF TRUTH: HSSMSpine/docs-brand/main.html — synced by
+    scripts/sync_docs_brand.py; do not edit the vendored copies.
+    Repo-agnostic: all links derive from config.repo_url. -#}
 {% extends "base.html" %}
-
 {% block announce %}
 <span class="show-on-small right-margin">
     <span class="twemoji right-margin show-on-small move-down">
@@ -8,11 +11,17 @@
     Navigate the site here!
 </span>
 <span class="right-margin">
-    <a href="https://github.com/lnccbrown/ssm-simulators/releases/latest">A new release is out!</a>
+    <a href="{{ config.repo_url | trim('/') }}/releases/latest">
+        A new release is out — read the release notes
+    </a>
 </span>
 <span>
     <span class="twemoji">
         {% include ".icons/material/head-question.svg" %}
     </span>
+    Questions?
+    <a href="https://github.com/lnccbrown/HSSM/discussions">
+        Open a discussion!
+    </a>
 </span>
 {% endblock %}

--- a/docs/styles/extra.css
+++ b/docs/styles/extra.css
@@ -1,6 +1,7 @@
 /* HSSM ecosystem brand tokens + shared helpers.
-   SOURCE OF TRUTH: HSSMSpine/docs-brand/extra.css — synced into each repo by
-   scripts/sync_docs_brand.py; do not edit the vendored copies. */
+   VENDORED COPY — source of truth: https://github.com/lnccbrown/HSSMSpine
+   (docs-brand/extra.css). Edit there and re-sync; local edits will be
+   flagged as drift. */
 
 /* -- palette (ocean = light/auto, slate = dark) -- */
 [data-md-color-scheme="ocean"] {
@@ -57,10 +58,6 @@ div .jp-RenderedText {
   width: 200px;
 }
 
-.md-header-__title {
-  font-size: 1rem;
-}
-
 div .md-sidebar__inner {
   margin-left: 0.2rem;
 }
@@ -97,10 +94,10 @@ div .md-sidebar__inner nav .md-nav__list {
 
 .move-down {
   transform: translate(0px, -5px);
-  animation: down_movement 1000ms infinite ease-out;
+  animation: down-movement 1000ms infinite ease-out;
 }
 
-@keyframes down_movement {
+@keyframes down-movement {
   to {
     transform: translate(0px, 5px);
   }

--- a/docs/styles/extra.css
+++ b/docs/styles/extra.css
@@ -1,3 +1,8 @@
+/* HSSM ecosystem brand tokens + shared helpers.
+   SOURCE OF TRUTH: HSSMSpine/docs-brand/extra.css — synced into each repo by
+   scripts/sync_docs_brand.py; do not edit the vendored copies. */
+
+/* -- palette (ocean = light/auto, slate = dark) -- */
 [data-md-color-scheme="ocean"] {
   --md-primary-fg-color: #245c81;
   --md-accent-fg-color: #ec205b;
@@ -8,4 +13,101 @@
   --md-primary-fg-color: #245c81;
   --md-accent-fg-color: #ec205b;
   --md-typeset-a-color: #00b4b5;
+}
+
+/* -- shared typography -- */
+.md-typeset h1 {
+  font-weight: 300;
+}
+
+h2 {
+  font-weight: 700;
+}
+
+.md-typeset code {
+  font-size: 0.7rem;
+}
+
+.md-typeset table:not([class]) {
+  font-size: 0.7rem;
+}
+
+/* -- notebook output sizing (was inline in HSSM's main.html) -- */
+pre {
+  font-size: 0.7rem;
+}
+
+.jp-OutputArea-executeResult pre,
+.jp-xr-text-repr-fallback pre,
+.jupyter-wrapper .jp-RenderedText pre {
+  font-size: 0.7rem !important;
+}
+
+.xr-sections {
+  font-size: 0.7rem;
+}
+
+div .jp-RenderedText {
+  font-size: 0.7rem !important;
+}
+
+/* -- header/sidebar tweaks -- */
+.md-header-nav__title img {
+  height: 200px;
+  width: 200px;
+}
+
+.md-header-__title {
+  font-size: 1rem;
+}
+
+div .md-sidebar__inner {
+  margin-left: 0.2rem;
+}
+
+div .md-sidebar__inner nav .md-nav__list {
+  margin-left: 0.2rem;
+}
+
+/* -- landing-page grid -- */
+#wrapper {
+  display: grid;
+  grid-template-columns: 33.334% 66.667%;
+}
+
+#main-logo {
+  text-align: center;
+}
+
+#main-title {
+  padding-top: 1.3em;
+  padding-left: 1em;
+}
+
+/* -- announcement-banner helpers (used by the shared main.html) -- */
+.right-margin {
+  margin-right: 10px;
+}
+
+@media screen and (min-width: 1220px) {
+  .show-on-small {
+    display: none;
+  }
+}
+
+.move-down {
+  transform: translate(0px, -5px);
+  animation: down_movement 1000ms infinite ease-out;
+}
+
+@keyframes down_movement {
+  to {
+    transform: translate(0px, 5px);
+  }
+}
+
+.question {
+  color: pink;
+  width: 35px;
+  height: 35px;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,28 +51,39 @@ plugins:
       default_handler: python
       handlers:
         python:
-          import:
+          inventories:
             - https://docs.python.org/3/objects.inv
             - https://mkdocstrings.github.io/objects.inv
             - https://mkdocstrings.github.io/griffe/objects.inv
           options:
+            # package-specific: API pages are per-module roll-ups
+            # (e.g. ':::ssms.basic_simulators')
             show_submodules: true
             separate_signature: true
             merge_init_into_class: true
             docstring_options:
               ignore_init_summary: true
-            docstring_style: "numpy"
-            docstring_section_style: "list"
+            docstring_style: numpy
+            docstring_section_style: list
             show_root_members_full_path: true
             show_object_full_path: false
-            show_category_heading: true
-            show_signature_annotations: false
+            show_category_heading: false
+            show_signature_annotations: true
+            show_docstring_attributes: false
             show_source: false
-            group_by_category: false
-            signature_crossrefs: true
+            show_root_heading: true
+            group_by_category: true
+            signature_crossrefs: false
+            summary: true
+            line_length: 80
+            unwrap_annotated: false
+            modernize_annotations: true
+            filters:
+              - "!^_"
 
 theme:
   logo: images/navlogo.png
+  favicon: images/navlogo.png
   name: material
   custom_dir: docs/overrides
   features:
@@ -82,6 +93,8 @@ theme:
     - navigation.sections
     - navigation.path
     - navigation.top
+    - navigation.footer
+    - navigation.indexes
     - content.code.copy
     - content.action.view
     - content.action.edit
@@ -112,13 +125,26 @@ theme:
         icon: material/brightness-4
         name: Switch to automatic mode
 
+copyright: >-
+  Copyright &copy; Brown University —
+  <a href="https://lnccbrown.github.io/HSSM/">HSSM</a> ·
+  <a href="https://lnccbrown.github.io/ssm-simulators/">ssm-simulators</a> ·
+  <a href="https://lnccbrown.github.io/LANfactory/">LANfactory</a>
+
 extra:
   homepage: "https://lnccbrown.github.io/ssm-simulators/"
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/lnccbrown/ssm-simulators
+    - icon: material/forum
+      link: https://github.com/lnccbrown/HSSM/discussions
 
 extra_css:
   - "styles/extra.css"
 
 markdown_extensions:
+  - toc:
+      permalink: true
   - admonition
   - pymdownx.highlight:
       anchor_linenums: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ docs = [
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.5.0",
     "mkdocs-jupyter>=0.24.0",
-    "mkdocstrings[python]>=0.24.0",
+    "mkdocstrings[python]>=1.0.0",
     # <1.2.3: the 1.2.3 release moved to the ProperDocs mkdocs fork — it
     # force-installs `properdocs`, caps mkdocs<=1.6.1, and injects an ad
     # banner into every mkdocs build. 1.2.2 is the last canonical release.
@@ -102,7 +102,7 @@ docs = [
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.5.0",
     "mkdocs-jupyter>=0.24.0",
-    "mkdocstrings[python]>=0.24.0",
+    "mkdocstrings[python]>=1.0.0",
     # <1.2.3: the 1.2.3 release moved to the ProperDocs mkdocs fork — it
     # force-installs `properdocs`, caps mkdocs<=1.6.1, and injects an ad
     # banner into every mkdocs build. 1.2.2 is the last canonical release.


### PR DESCRIPTION
Phase 1 of the ecosystem docs overhaul: vendor the shared brand bundle from the spine (lnccbrown/HSSMSpine#42) and apply the canonical `mkdocs.yml` blocks, so this site carries the same visual identity as HSSM and LANfactory. Rebased on top of the phase-0 safety net (#321).

## What changed

- **Broken banner CSS fixed** — the announcement banner used helper classes (`right-margin`, `show-on-small`, `move-down`) that `docs/styles/extra.css` never defined here; the full bundle CSS supplies them, plus the shared typography/notebook-output tokens. The banner template itself is now repo-agnostic (release link derives from `repo_url` instead of a hardcoded URL).
- **Favicon added** — `images/navlogo.png` instead of the Material default.
- **Ecosystem footer strip** — every page's footer links HSSM · ssm-simulators · LANfactory; social icons point at this repo and HSSM Discussions (one community forum for the ecosystem).
- **Prev/next page links enabled** — `navigation.footer` (+ `navigation.indexes`, `toc: permalink: true`).
- **API-page rendering unified with HSSM** — mkdocstrings options mirrored from HSSM's block (modern `inventories:` key instead of deprecated `import:`, `filters: ["!^_"]`, identical rendering options), keeping `show_submodules: true` as this repo's package-specific bit (its API pages are per-module roll-ups).

## Verification

- `uv run mkdocs build --strict` passes with **0 warnings** on top of #321.
- Rendered site checked: favicon link, copyright strip, prev/next footer, social icons, and `repo_url`-derived release link all present.
- No notebooks or content pages touched; bundle files are byte-identical to the spine copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a banner explaining documentation source and synchronization requirements.
  * Updated announcement links for release notes and community discussions.
  * Improved API reference presentation with clearer signatures, annotations, filtering, and cross-references.
  * Added favicon, enhanced navigation, table-of-contents permalinks, footer links, and social links.
  * Updated documentation tooling for improved reference generation.

* **Style**
  * Added refreshed branding and responsive documentation styling.
  * Improved typography, notebook output sizing, page layouts, banners, headers, sidebars, and question prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->