### PR TITLE
Add --n-cpus, and stop discarding the pipeline config

### DIFF
--- a/ssms/cli/generate.py
+++ b/ssms/cli/generate.py
@@ -123,12 +123,17 @@ def collect_data_generator_config(
         "cpn_only": True if (bc.generator_approach == "cpn") else False,
     }
 
-    # Add pipeline config
+    # Add pipeline config.
+    #
+    # Forward every key the YAML declares rather than naming them one by one.
+    # This used to enumerate n_parameter_sets and n_subruns, which silently
+    # discarded `n_cpus` — a documented pipeline setting with a default in the
+    # generator config — so setting it in a YAML did nothing and gave no
+    # warning. Any key added to the pipeline section in future is now reachable
+    # without a second edit here. The deep merge in
+    # make_data_generator_configs leaves unset keys at their defaults.
     if hasattr(bc, "pipeline"):
-        data_generator_nested_dict["pipeline"] = {
-            "n_parameter_sets": bc.pipeline.n_parameter_sets,
-            "n_subruns": bc.pipeline.n_subruns,
-        }
+        data_generator_nested_dict["pipeline"] = bc.pipeline._asdict()
 
     # Add simulator config
     if hasattr(bc, "simulator"):
@@ -254,11 +259,32 @@ def setup_mlflow(  # pragma: no cover
         return False
 
 
+def parse_n_cpus(value: str | int | None) -> str | int | None:
+    """Validate a --n-cpus value: a positive integer, or the sentinel 'all'.
+
+    'all' is resolved later, at generator construction, from the cores this
+    process may actually use — under a scheduler that is the job's cpuset, not
+    the machine's core count.
+    """
+    if value is None or value == "all":
+        return value
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise typer.BadParameter(
+            f"--n-cpus must be a positive integer or 'all', got {value!r}."
+        ) from None
+    if parsed < 1:
+        raise typer.BadParameter(f"--n-cpus must be >= 1, got {parsed}.")
+    return parsed
+
+
 def load_config(  # pragma: no cover
     config_path: Path,
     output: Path,
     estimator_type: str,
     logger: logging.Logger,
+    n_cpus: str | int | None = None,
 ) -> tuple[dict, str | None]:
     """
     Load and prepare the generator configuration.
@@ -298,6 +324,13 @@ def load_config(  # pragma: no cover
     if estimator_type is not None:
         logger.info(f"Overriding estimator_type from CLI: {estimator_type}")
         config_dict["data_config"]["estimator_type"] = estimator_type.lower()
+
+    # Override n_cpus if specified via CLI. A post-construction override, like
+    # estimator_type above, so the precedence is unambiguous and visible in one
+    # place: CLI > YAML > the generator config's packaged default of "all".
+    if n_cpus is not None:
+        config_dict["data_config"].setdefault("pipeline", {})["n_cpus"] = n_cpus
+        logger.info("Overriding n_cpus from CLI: %s", n_cpus)
 
     logger.debug("GENERATOR CONFIG")
     logger.debug(pformat(config_dict["data_config"]))
@@ -554,6 +587,17 @@ def main(  # pragma: no cover
         min=1,
         show_default=True,
     ),
+    n_cpus: str = typer.Option(
+        None,
+        "--n-cpus",
+        help=(
+            "Worker processes used to generate parameter sets. An integer, or "
+            "'all' for every core this process is allowed to use — under a "
+            "scheduler that is the cpuset granted to the job (e.g. SLURM's "
+            "--cpus-per-task), not the machine's core count. Overrides "
+            "PIPELINE.N_CPUS in the config. [default: the config value, else 'all']"
+        ),
+    ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
@@ -633,7 +677,7 @@ def main(  # pragma: no cover
 
     # Load and prepare configuration
     config_dict, config_sha256 = load_config(
-        config_path, output, estimator_type, logger
+        config_path, output, estimator_type, logger, n_cpus=parse_n_cpus(n_cpus)
     )
 
     # Log initial config to MLflow

--- a/ssms/cli/generate.py
+++ b/ssms/cli/generate.py
@@ -108,6 +108,45 @@ def get_basic_config_from_yaml(
     return bc, training_data_folder
 
 
+def parse_n_cpus(value: str | int | None, source: str = "--n-cpus") -> str | int | None:
+    """Validate an n_cpus value: a positive integer, or the sentinel 'all'.
+
+    Applied to BOTH entry points — the CLI option and the YAML's
+    PIPELINE.N_CPUS — so neither can smuggle a bad value into the generator.
+    ``source`` only names the offender in the message.
+
+    Zero is the value worth catching: it is falsy but not 'all', so it would
+    slip past the pool's ``n_cpus > 1`` gate and silently run sequentially.
+    A non-numeric string is worse — it reaches that same comparison and raises
+    a TypeError deep inside the generator instead of here.
+
+    'all' is resolved later, at generator construction, from the cores this
+    process may actually use — under a scheduler that is the job's cpuset, not
+    the machine's core count.
+    """
+    if value is None or value == "all":
+        return value
+    if isinstance(value, bool):  # bool is an int subclass; True would pass as 1
+        raise typer.BadParameter(
+            f"{source} must be an integer or 'all', got {value!r}."
+        )
+    if isinstance(value, float) and not value.is_integer():
+        # int(2.5) is 2, so a YAML float would silently truncate the worker
+        # count rather than being rejected.
+        raise typer.BadParameter(
+            f"{source} must be a whole number or 'all', got {value!r}."
+        )
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise typer.BadParameter(
+            f"{source} must be a positive integer or 'all', got {value!r}."
+        ) from None
+    if parsed < 1:
+        raise typer.BadParameter(f"{source} must be >= 1, got {parsed}.")
+    return parsed
+
+
 def collect_data_generator_config(
     yaml_config_path=None, base_path=None, extra_configs={}
 ) -> dict[str, Any]:
@@ -133,7 +172,14 @@ def collect_data_generator_config(
     # without a second edit here. The deep merge in
     # make_data_generator_configs leaves unset keys at their defaults.
     if hasattr(bc, "pipeline"):
-        data_generator_nested_dict["pipeline"] = bc.pipeline._asdict()
+        pipeline = bc.pipeline._asdict()
+        if "n_cpus" in pipeline:
+            # Same validation as the CLI path — forwarding the section
+            # wholesale would otherwise hand the generator an unchecked value.
+            pipeline["n_cpus"] = parse_n_cpus(
+                pipeline["n_cpus"], source="PIPELINE.N_CPUS"
+            )
+        data_generator_nested_dict["pipeline"] = pipeline
 
     # Add simulator config
     if hasattr(bc, "simulator"):
@@ -257,26 +303,6 @@ def setup_mlflow(  # pragma: no cover
             e,
         )
         return False
-
-
-def parse_n_cpus(value: str | int | None) -> str | int | None:
-    """Validate a --n-cpus value: a positive integer, or the sentinel 'all'.
-
-    'all' is resolved later, at generator construction, from the cores this
-    process may actually use — under a scheduler that is the job's cpuset, not
-    the machine's core count.
-    """
-    if value is None or value == "all":
-        return value
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
-        raise typer.BadParameter(
-            f"--n-cpus must be a positive integer or 'all', got {value!r}."
-        ) from None
-    if parsed < 1:
-        raise typer.BadParameter(f"--n-cpus must be >= 1, got {parsed}.")
-    return parsed
 
 
 def load_config(  # pragma: no cover
@@ -662,9 +688,10 @@ def main(  # pragma: no cover
     )
     logger = logging.getLogger(__name__)
 
-    # Parse tags before ANY MLflow work so a malformed --mlflow-tag fails
+    # Parse tags and --n-cpus before ANY MLflow work so a malformed value fails
     # fast without leaving a junk empty run in the tracking store.
     extra_tags = parse_mlflow_tags(mlflow_tag)
+    resolved_n_cpus = parse_n_cpus(n_cpus)
 
     # Setup MLflow
     mlflow_active = setup_mlflow(
@@ -677,7 +704,7 @@ def main(  # pragma: no cover
 
     # Load and prepare configuration
     config_dict, config_sha256 = load_config(
-        config_path, output, estimator_type, logger, n_cpus=parse_n_cpus(n_cpus)
+        config_path, output, estimator_type, logger, n_cpus=resolved_n_cpus
     )
 
     # Log initial config to MLflow

--- a/ssms/dataset_generators/lan_mlp.py
+++ b/ssms/dataset_generators/lan_mlp.py
@@ -361,6 +361,17 @@ class TrainingDataGenerator:  # noqa: N801
             self.generator_config["pipeline"] = {}
         self.generator_config["pipeline"]["n_cpus"] = n_cpus
 
+        # Say what will actually run, not just what was requested. The worker
+        # count differs from n_cpus, and n_cpus itself may have been inferred
+        # rather than set — without this line neither is recoverable from a
+        # finished run's logs or its MLflow record.
+        logger.info(
+            "Parameter-set generation will use %s.",
+            f"{n_cpus - 1} worker processes (n_cpus={n_cpus})"
+            if n_cpus > 1
+            else "no multiprocessing (n_cpus=1)",
+        )
+
     def _save_training_data(self, data: dict) -> None:
         """Save training data to disk as pickle file.
 

--- a/tests/test_generate_cli.py
+++ b/tests/test_generate_cli.py
@@ -271,3 +271,36 @@ def test_parse_n_cpus_rejects_invalid_values(value):
 
     with pytest.raises(typer.BadParameter):
         parse_n_cpus(value)
+
+
+@pytest.mark.parametrize("bad", [0, -1, "eight", 2.5, True])
+def test_invalid_yaml_n_cpus_is_rejected_not_forwarded(tmp_path, yaml_config, bad):
+    """The YAML path must validate too.
+
+    Forwarding the pipeline section wholesale is what makes N_CPUS reachable;
+    it also means an unchecked value would reach the generator. Zero is the
+    nastiest: falsy but not 'all', so it slips past the pool's `n_cpus > 1`
+    gate and silently runs sequentially instead of erroring.
+    """
+    import typer
+
+    yaml_config["PIPELINE"]["N_CPUS"] = bad
+    with pytest.raises(typer.BadParameter):
+        _config_from(yaml_config, tmp_path)
+
+
+def test_yaml_n_cpus_all_sentinel_still_passes(tmp_path, yaml_config):
+    yaml_config["PIPELINE"]["N_CPUS"] = "all"
+    config = _config_from(yaml_config, tmp_path)
+    assert config["data_config"]["pipeline"]["n_cpus"] == "all"
+
+
+def test_parse_n_cpus_names_the_offending_source():
+    import typer
+
+    from ssms.cli.generate import parse_n_cpus
+
+    with pytest.raises(typer.BadParameter, match="PIPELINE.N_CPUS"):
+        parse_n_cpus(0, source="PIPELINE.N_CPUS")
+    with pytest.raises(typer.BadParameter, match="--n-cpus"):
+        parse_n_cpus(0)

--- a/tests/test_generate_cli.py
+++ b/tests/test_generate_cli.py
@@ -219,3 +219,55 @@ class TestParseMlflowTags:
         for reserved in ("schema_version=2", "phase=custom"):
             with pytest.raises(typer.BadParameter):
                 parse_mlflow_tags([reserved])
+
+
+# n_cpus: the pipeline section used to be forwarded key-by-key, which silently
+# discarded every field except n_parameter_sets and n_subruns.
+
+
+def _config_from(yaml_dict, tmp_path):
+    buffer = io.StringIO()
+    yaml.dump(yaml_dict, buffer)
+    buffer.seek(0)
+    return collect_data_generator_config(yaml_config_path=buffer, base_path=tmp_path)
+
+
+def test_pipeline_n_cpus_from_yaml_reaches_the_generator_config(tmp_path, yaml_config):
+    """The regression this fixes: N_CPUS was accepted and thrown away."""
+    yaml_config["PIPELINE"]["N_CPUS"] = 4
+    config = _config_from(yaml_config, tmp_path)
+    assert config["data_config"]["pipeline"]["n_cpus"] == 4
+
+
+def test_pipeline_defaults_survive_a_partial_yaml(tmp_path, yaml_config):
+    # Forwarding the whole section must not wipe keys the YAML omits.
+    config = _config_from(yaml_config, tmp_path)
+    pipeline = config["data_config"]["pipeline"]
+    assert pipeline["n_parameter_sets"] == 10
+    assert pipeline["n_subruns"] == 1
+    assert pipeline["n_cpus"] == "all"  # packaged default, untouched
+
+
+def test_unknown_pipeline_keys_are_forwarded_not_dropped(tmp_path, yaml_config):
+    # The point of forwarding the section wholesale: a new key needs no second
+    # edit in the CLI bridge to become reachable.
+    yaml_config["PIPELINE"]["N_PARAMETER_SETS_REJECTED"] = 7
+    config = _config_from(yaml_config, tmp_path)
+    assert config["data_config"]["pipeline"]["n_parameter_sets_rejected"] == 7
+
+
+@pytest.mark.parametrize("value,expected", [("all", "all"), ("8", 8), (None, None)])
+def test_parse_n_cpus_accepts_valid_values(value, expected):
+    from ssms.cli.generate import parse_n_cpus
+
+    assert parse_n_cpus(value) == expected
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "eight", "2.5"])
+def test_parse_n_cpus_rejects_invalid_values(value):
+    import typer
+
+    from ssms.cli.generate import parse_n_cpus
+
+    with pytest.raises(typer.BadParameter):
+        parse_n_cpus(value)


### PR DESCRIPTION
`PIPELINE.N_CPUS` has been a documented setting with a packaged default of `"all"` since the generator config was written ([data_generator_config.py:47](ssms/config/generator_config/data_generator_config.py#L47)). Setting it in a YAML has never done anything, silently.

## The cause is not a missing key

`collect_data_generator_config` built the pipeline section as a **hardcoded two-key dict**:

```python
data_generator_nested_dict["pipeline"] = {
    "n_parameter_sets": bc.pipeline.n_parameter_sets,
    "n_subruns": bc.pipeline.n_subruns,
}
```

so every other pipeline field was dropped between the YAML and the generator. It now forwards `bc.pipeline._asdict()` — which also means the *next* key added to that section becomes reachable without a second edit here. The deep merge in `make_data_generator_configs` leaves unset keys at their defaults, so partial YAMLs are unaffected (there's a test).

## `--n-cpus`

An integer, or `"all"` for every core the process may use. Under a scheduler that is the job's cpuset, not the machine's core count — `_get_ncpus` already tries `sched_getaffinity` first, so `"all"` was always correct under SLURM; there was simply no way to say anything else.

Precedence is **CLI > YAML > packaged default**, implemented as a post-construction override next to the existing `--estimator-type` one so all the overrides sit in one readable place.

## It now says what it will actually do

The pool takes `n_cpus - 1` workers, and `n_cpus` itself may have been inferred rather than set — so neither number was recoverable from a finished run. One new log line:

```
Resolved 'n_cpus'='all' to 18 cores.
Parameter-set generation will use 17 worker processes (n_cpus=18).
```

This is not cosmetic. Answering "how many cores is this 300-task production array actually using" required sshing to a compute node and reading `ps` output this week. It should be in the log.

## Verified end to end

| | |
|---|---|
| no flag | `"all"` → 18 cores → 17 workers |
| `--n-cpus 3` | 2 workers |
| `--n-cpus 1` | sequential path, no pool |
| `--n-cpus 0` | clean `BadParameter`, not a traceback |
| YAML `N_CPUS: 2` | **arrives** (1 worker) — the regression |
| YAML 2 + `--n-cpus 4` | 3 workers — CLI wins |

Six new tests cover the YAML forwarding, defaults surviving a partial YAML, an unrelated key riding through, and the validator's accept/reject cases.

`1032 passed, 134 skipped`, ruff clean.

## Follow-up, deliberately not in here

`processes=n_cpus - 1` ([lan_mlp.py:462](ssms/dataset_generators/lan_mlp.py#L462)) leaves one core of the allocation idle. Measured on a live SLURM task: the parent sits at **0.0% CPU** for the entire `pool.map` (it is blocking, and its aggregation happens only after the workers finish), so nothing uses the reserved core — and under a cgroup nothing else *can*. That is a behaviour change and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--n-cpus` option for configuring the number of CPU workers.
  * Supports positive integer values or `all` for automatic CPU usage.
  * Command-line values override CPU settings in pipeline configuration files.
  * Pipeline configuration now preserves additional supported settings.

* **Bug Fixes**
  * Improved reporting of the effective CPU and multiprocessing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->