### PR TITLE
One pool worker per allowed CPU, not n_cpus - 1

### DIFF
--- a/ssms/dataset_generators/lan_mlp.py
+++ b/ssms/dataset_generators/lan_mlp.py
@@ -367,7 +367,7 @@ class TrainingDataGenerator:  # noqa: N801
         # finished run's logs or its MLflow record.
         logger.info(
             "Parameter-set generation will use %s.",
-            f"{n_cpus - 1} worker processes (n_cpus={n_cpus})"
+            f"{n_cpus} worker processes (n_cpus={n_cpus})"
             if n_cpus > 1
             else "no multiprocessing (n_cpus=1)",
         )
@@ -468,9 +468,28 @@ class TrainingDataGenerator:  # noqa: N801
             start_idx = i * subrun_n
             end_idx = (i + 1) * subrun_n
 
+            # One worker per allowed CPU, not n_cpus - 1.
+            #
+            # The reserved core was presumably meant to keep the parent
+            # responsive, which is the right instinct when the parent works
+            # while the workers do — an imap/imap_unordered consumer, a feeder,
+            # a progress loop. This parent does none of that: pool.map is
+            # blocking and eager, so it sleeps until every result is back, and
+            # its aggregation (out_list, the concat, the pickle write) happens
+            # afterwards when the workers are already idle. The two phases
+            # never overlap, so there is no contention to protect against.
+            #
+            # Measured on a live SLURM task with -c 8: parent 0.0% CPU over
+            # 2h12m (state Sl), 7 workers at 99.6% each — one of the eight
+            # allocated cores simply idle. Under a cgroup nothing else can use
+            # it either, so it is billed and wasted rather than lent back.
+            #
+            # If this ever moves to imap_unordered with incremental
+            # aggregation — which would be a good change, overlapping result
+            # unpickling with compute — reinstate the reservation.
             if self.generator_config["pipeline"]["n_cpus"] > 1:
                 with Pool(
-                    processes=self.generator_config["pipeline"]["n_cpus"] - 1
+                    processes=self.generator_config["pipeline"]["n_cpus"]
                 ) as pool:
                     # Map strategy.generate_for_parameter_set over parameter indices
                     results = pool.map(

--- a/tests/dataset_generators/test_training_data_generator.py
+++ b/tests/dataset_generators/test_training_data_generator.py
@@ -418,3 +418,52 @@ class TestTrainingDataGeneratorPipelineIntegration:
 
         # Both should produce compatible data shapes
         assert data_kde["lan_data"].shape[1] == data_pyddm["lan_data"].shape[1]
+
+
+class TestPoolWorkerCount:
+    """The pool takes one worker per allowed CPU, not n_cpus - 1.
+
+    The reserved core was protecting a parent that does no concurrent work:
+    pool.map is blocking, and the parent's aggregation runs afterwards, when
+    the workers are already idle. Measured on a live SLURM task with -c 8, the
+    parent sat at 0.0% CPU for 2h12m while 7 workers ran at 99.6% — one of
+    eight allocated cores idle, and under a cgroup unusable by anything else.
+    """
+
+    def _spawned_worker_counts(self, monkeypatch, n_cpus, n_parameter_sets=4):
+        from ssms.dataset_generators import lan_mlp
+
+        seen = []
+
+        class RecordingPool:
+            def __init__(self, processes=None, **kwargs):
+                seen.append(processes)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def map(self, fn, *iterables):
+                return [fn(*args) for args in zip(*iterables)]
+
+        monkeypatch.setattr(lan_mlp, "Pool", RecordingPool)
+
+        gen_config = get_default_generator_config("lan", model="ddm")
+        gen_config["pipeline"]["n_cpus"] = n_cpus
+        gen_config["pipeline"]["n_parameter_sets"] = n_parameter_sets
+        gen_config["pipeline"]["n_subruns"] = 1
+        gen_config["simulator"]["n_samples"] = 100
+        gen_config["training"]["n_samples_per_param"] = 5
+
+        gen = lan_mlp.TrainingDataGenerator(config=gen_config)
+        gen.generate_data_training(save=False, verbose=False)
+        return seen
+
+    def test_pool_gets_one_worker_per_allowed_cpu(self, monkeypatch):
+        assert self._spawned_worker_counts(monkeypatch, n_cpus=4) == [4]
+
+    def test_no_pool_when_only_one_cpu_is_allowed(self, monkeypatch):
+        # The sequential branch, not a one-worker pool.
+        assert self._spawned_worker_counts(monkeypatch, n_cpus=1) == []


### PR DESCRIPTION
**Behaviour change.** Stacked on #326 — the base is `feat/n-cpus-flag`, so review that first. Retarget to `main` once it merges.

## Why the reservation does not pay here

Reserving a core for the parent is right **when the parent works while the workers do** — an `imap`/`imap_unordered` consumer, a feeder thread, a progress loop. Starve that parent and it becomes the bottleneck.

This parent does none of that. `pool.map` is blocking and eager: it sleeps until every result is back, and the aggregation (`out_list`, the concat, the pickle write) runs *afterwards*, when the workers have already finished and their cores are free. The two phases never overlap, so there is no contention to protect against.

**Measured on a live SLURM task with `-c 8`:**

```
parent   0.0% CPU   state Sl   after 2h12m
worker   99.6%  x7
                    ─────
         6.97 of 8 allocated cores
```

One core idle for the whole 3.5-hour task. On a workstation that core goes to the OS; under a cgroup **nothing else can borrow it**, so it is billed and wasted.

## It also removes a tuning trap

The waste is a fixed one core per task, so it hurts more the thinner the tasks are. At a 272-core QOS cap:

| | workers = `n_cpus - 1` | workers = `n_cpus` |
|---|---|---|
| `-c 8` | 238 busy (87%) | **272 (100%)** |
| `-c 16` | 255 busy (94%) | **272 (100%)** |
| `-c 34` | 264 busy (97%) | **272 (100%)** |

With the `-1`, the best `-c` depends on your core cap and users have to work it out. Without it, any `c` that divides the cap saturates it.

## What the local benchmark does and does not show

On an 18-core laptop at `n_cpus=4` (3 → 4 workers): **5.20s → 5.03s**, median of 3. Only ~3%, and I am reporting it rather than burying it — a laptop A/B *understates* this change, because there the reserved core is not idle at all, the OS uses it. The cgroup case is the one the change is for.

## Tests

Two tests pin the contract by recording what the pool is constructed with: one worker per allowed CPU, and no pool at all when `n_cpus == 1` (the sequential branch, not a one-worker pool).

`1041 passed`, ruff clean.

## If the execution model changes

Moving to `imap_unordered` with incremental aggregation would be a good change — it would overlap result unpickling with compute and cut the serial tail. **It would also make the reservation correct again.** The comment at the call site says so, so this does not get silently re-broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPU worker allocation during multiprocessing so all configured workers are used.
  * Updated runtime reporting to consistently show the actual number of workers.
  * Preserved sequential processing when only one CPU is available.

* **Tests**
  * Added coverage for multiprocessing and single-CPU execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->