### PR TITLE
docs: Diátaxis nav restructure — Learn / How-to / Explanations / Reference

### DIFF
--- a/docs/basic_tutorial/basic_tutorial.ipynb
+++ b/docs/basic_tutorial/basic_tutorial.ipynb
@@ -5,7 +5,7 @@
    "id": "2b354785",
    "metadata": {},
    "source": [
-    "# Basic Tutorial: Simulate and Inspect Sequential Sampling Models\n",
+    "# Simulate and inspect your first SSM\n",
     "\n",
     "This tutorial introduces the main `ssm-simulators` workflow: create a\n",
     "simulator, generate reaction times and choices, inspect the result, and\n",

--- a/docs/contributing/add_parameter_adapters.md
+++ b/docs/contributing/add_parameter_adapters.md
@@ -1,4 +1,4 @@
-# Custom Parameter Transforms
+# Write a custom parameter transform
 
 ## Overview
 

--- a/docs/core_tutorials/choice_only_rl_models.ipynb
+++ b/docs/core_tutorials/choice_only_rl_models.ipynb
@@ -5,7 +5,7 @@
    "id": "db7c95d9",
    "metadata": {},
    "source": [
-    "# Choice-only RL Models\n",
+    "# Simulate choice-only RL models\n",
     "\n",
     "Audience:\n",
     "- Users modeling choices without response-time likelihoods.\n",

--- a/docs/core_tutorials/kde_class.ipynb
+++ b/docs/core_tutorials/kde_class.ipynb
@@ -8,7 +8,7 @@
     }
    },
    "source": [
-    "# Using the KDE class"
+    "# Estimate a likelihood with the KDE class"
    ]
   },
   {

--- a/docs/core_tutorials/rlssm_advanced_tutorial.ipynb
+++ b/docs/core_tutorials/rlssm_advanced_tutorial.ipynb
@@ -5,7 +5,7 @@
    "id": "5d5c7f2e",
    "metadata": {},
    "source": [
-    "# RLSSM Simulators: Advanced Tutorial\n",
+    "# Build custom RLSSM components\n",
     "\n",
     "This is the **advanced** companion to the\n",
     "[RLSSM beginner tutorial](rlssm_tutorial.ipynb). The beginner tutorial showed the\n",

--- a/docs/core_tutorials/rlssm_simulation_hssm_handoff.ipynb
+++ b/docs/core_tutorials/rlssm_simulation_hssm_handoff.ipynb
@@ -5,7 +5,7 @@
    "id": "693f8d95",
    "metadata": {},
    "source": [
-    "# RLSSM Simulation and HSSM Handoff\n",
+    "# Hand off simulated RLSSM data to HSSM\n",
     "\n",
     "Audience:\n",
     "- Users who can already simulate a basic SSM and now want trial-wise learning models.\n",

--- a/docs/core_tutorials/rlssm_tutorial.ipynb
+++ b/docs/core_tutorials/rlssm_tutorial.ipynb
@@ -5,7 +5,7 @@
    "id": "556014e5",
    "metadata": {},
    "source": [
-    "# RLSSM Simulators: A Beginner's Tutorial\n",
+    "# Simulate your first RLSSM\n",
     "\n",
     "This tutorial is a gentle, end-to-end introduction to the **reinforcement-learning\n",
     "sequential sampling model (RLSSM)** simulator in `ssm-simulators`, exposed through the\n",

--- a/docs/core_tutorials/tutorial_capabilities.ipynb
+++ b/docs/core_tutorials/tutorial_capabilities.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Package Overview\n",
+    "# What ssm-simulators can do\n",
     "\n",
     "This tutorial surveys the capabilities of `ssm-simulators` organized around the two core use-cases that `ssm-simulators` is build around."
    ]

--- a/docs/core_tutorials/tutorial_configs.ipynb
+++ b/docs/core_tutorials/tutorial_configs.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Configuration Systems\n",
+    "# Configuration systems\n",
     "\n",
     "## Overview\n",
     "\n",

--- a/docs/core_tutorials/tutorial_custom_models.ipynb
+++ b/docs/core_tutorials/tutorial_custom_models.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Creating Custom Models\n",
+    "# Create a custom model\n",
     "\n",
     "## Overview\n",
     "\n",

--- a/docs/core_tutorials/tutorial_data_generators.ipynb
+++ b/docs/core_tutorials/tutorial_data_generators.ipynb
@@ -5,7 +5,7 @@
    "id": "3576edb7",
    "metadata": {},
    "source": [
-    "# The TrainingDataGenerator class\n",
+    "# Generate training data for LANs\n",
     "\n",
     "This tutorial demonstrates how to use the `TrainingDataGenerator` class to create training data for sequential sampling models (SSMs). \n",
     "We'll discuss a bit of the overall workflow design here as well."

--- a/docs/core_tutorials/tutorial_simulators_vs_pyddm.ipynb
+++ b/docs/core_tutorials/tutorial_simulators_vs_pyddm.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Tutorial: Native simulators vs. PyDDM Analytical Solutions\n",
+    "# Simulation vs. analytical solutions (PyDDM)\n",
     "\n",
     "`ssm-simulators` allows you to define a `PyDDM` model via a wrapper class that let's us instantiate a `PyDDM` model from our `model_config`'s directly.\n",
     "\n",

--- a/docs/core_tutorials/using_mlflow.md
+++ b/docs/core_tutorials/using_mlflow.md
@@ -1,4 +1,4 @@
-# MLflow Tutorial for SSM-Simulators
+# Track data generation runs with MLflow
 
 Track and manage your data generation experiments with MLflow.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,31 +7,32 @@ edit_uri: edit/main/docs
 nav:
   - Home:
       - Overview: index.md
-  - Getting Started:
-      - Basic Tutorial: basic_tutorial/basic_tutorial.ipynb
-  - Core Tutorials:
-      - Package Overview: core_tutorials/tutorial_capabilities.ipynb
-      - Configuration Systems: core_tutorials/tutorial_configs.ipynb
-      - Custom Models: core_tutorials/tutorial_custom_models.ipynb
-      - Data Generators: core_tutorials/tutorial_data_generators.ipynb
-      - RLSSM Tutorial: core_tutorials/rlssm_tutorial.ipynb
-      - RLSSM Simulation and HSSM Handoff: core_tutorials/rlssm_simulation_hssm_handoff.ipynb
-      - Choice-only RL Models: core_tutorials/choice_only_rl_models.ipynb
-      - RLSSM Tutorial (Advanced): core_tutorials/rlssm_advanced_tutorial.ipynb
-      - KDE Class: core_tutorials/kde_class.ipynb
-      - PyDDM Integration: core_tutorials/tutorial_simulators_vs_pyddm.ipynb
-      - Using MLflow: core_tutorials/using_mlflow.md
+  - Learn:
+      - Simulate and inspect your first SSM: basic_tutorial/basic_tutorial.ipynb
+      - Simulate your first RLSSM: core_tutorials/rlssm_tutorial.ipynb
+  - How-to guides:
+      - Create a custom model: core_tutorials/tutorial_custom_models.ipynb
+      - Generate training data for LANs: core_tutorials/tutorial_data_generators.ipynb
+      - Estimate a likelihood with the KDE class: core_tutorials/kde_class.ipynb
+      - Simulate choice-only RL models: core_tutorials/choice_only_rl_models.ipynb
+      - Build custom RLSSM components: core_tutorials/rlssm_advanced_tutorial.ipynb
+      - Hand off simulated RLSSM data to HSSM: core_tutorials/rlssm_simulation_hssm_handoff.ipynb
+      - Write a custom parameter transform: contributing/add_parameter_adapters.md
+      - Track data generation runs with MLflow: core_tutorials/using_mlflow.md
+  - Explanations:
+      - What ssm-simulators can do: core_tutorials/tutorial_capabilities.ipynb
+      - Simulation vs. analytical solutions (PyDDM): core_tutorials/tutorial_simulators_vs_pyddm.ipynb
+  - Reference:
+      - Configuration systems: core_tutorials/tutorial_configs.ipynb
+      - API:
+          - RLSSM (ssms.rl): api/rlssm.md
+          - basic simulators: api/basic_simulators.md
+          - config: api/config.md
+          - data generators: api/dataset_generators.md
+          - support utils: api/support_utils.md
   - Contributing:
       - Overview: contributing/README.md
-      - Contribute New Models: contributing/add_models.md
-      - Contribute Parameter Adapters: contributing/add_parameter_adapters.md
-
-  - API:
-      - RLSSM (ssms.rl): api/rlssm.md
-      - basic simulators: api/basic_simulators.md
-      - config: api/config.md
-      - data generators: api/dataset_generators.md
-      - support utils: api/support_utils.md
+      - Add a new model: contributing/add_models.md
 
 validation:
   omitted_files: warn


### PR DESCRIPTION
Phase 3 of the ecosystem docs overhaul. All 20 nav entries preserved (verified programmatically); no file moves, no redirects, no re-execution.

- **"Core Tutorials" (11 pages) dissolves.** Classification found it 1-for-11: only `rlssm_tutorial` is a Diátaxis tutorial. Pages redistribute to Learn (2), How-to guides (6), Explanations (2), Reference (1).
- **Shared ecosystem section vocabulary** adopted — Home / Learn / How-to guides / Explanations / Reference / Contributing — matching HSSM and LANfactory so the tab strip is positionally identical when readers hop between sites.
- **API folds under `Reference`** (previously a sibling top-level tab), which is what makes "Reference" mean the same thing on every site.
- **`tutorial_configs` moves to Reference** — it opens with "What you'll learn" and then delivers a field-by-field glossary of `model_config`/`generator_config`; nothing is built and nothing carries forward.
- **`add_parameter_adapters.md` moves out of Contributing** into How-to guides: it has no fork/branch/PR steps, it is a user-facing recipe.
- **Task-first titles** on 11 notebooks + 2 markdown pages ("MLflow Tutorial for SSM-Simulators" → "Track data generation runs with MLflow"; "The TrainingDataGenerator class" → "Generate training data for LANs"). Notebook H1s are retitled too, since mkdocs-jupyter uses them as sidebar titles.

Page splits (notably `rlssm_advanced_tutorial`, which fuses four genres across 58 cells) are deferred to a follow-up — they are content surgery, not relabeling.

`mkdocs build --strict` green; new sections verified in the built sidebar.

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tutorial and guide titles to use clearer, action-oriented language.
  * Improved headings to better describe topics such as simulation, custom models, data generation, and likelihood estimation.
  * Reorganized documentation navigation into Learn, How-to guides, Explanations, and Reference sections.
  * Relabeled and reordered existing documentation pages for easier discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->