### PR TITLE
docs: point at the ecosystem hub instead of a partial map

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -64,22 +64,15 @@ ssms covers a broad simulator surface:
 
 ---
 
-## Ecosystem Fit
+## Ecosystem fit
 
 `ssm-simulators` is the simulator and data-generation layer of the HSSM
-ecosystem.
+ecosystem: it defines the models, simulates from them, and produces the
+training data that likelihood networks are fitted to.
 
-| Package | Role |
-| --- | --- |
-| [HSSM](https://github.com/lnccbrown/HSSM) | Consumes simulator-defined model contracts for Bayesian inference, including ssms-defined RLSSMs. |
-| [LANfactory](https://github.com/lnccbrown/LANfactory) | Trains likelihood approximation networks from ssms-generated data. |
-| [LAN_pipeline_minimal](https://github.com/lnccbrown/LAN_pipeline_minimal) | Runs data-generation and LAN-training pipelines. |
-
-For RLSSMs, ssms owns the learning rule, task environment, response mapping,
-simulation loop, and posterior predictive behavior. HSSM consumes the assembled
-ssms model through `hssm.rl.RLSSMConfig.from_ssms_model(...)`.
-
----
+For the full map — what each package owns, how artifacts flow between them,
+and which versions work together — see
+[The HSSM ecosystem](https://lnccbrown.github.io/HSSM/ecosystem/).
 
 ## Quick Start
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ edit_uri: edit/main/docs
 nav:
   - Home:
       - Overview: index.md
+      - The HSSM ecosystem: https://lnccbrown.github.io/HSSM/ecosystem/
   - Learn:
       - Simulate and inspect your first SSM: basic_tutorial/basic_tutorial.ipynb
       - Simulate your first RLSSM: core_tutorials/rlssm_tutorial.ipynb


### PR DESCRIPTION
Phase 4 companion to lnccbrown/HSSMSpine#48 (the spine-authored ecosystem hub, published at https://lnccbrown.github.io/HSSM/ecosystem/).

- The landing page's "Ecosystem Fit" table described the ecosystem from this package's vantage point and was incomplete — it omitted `ssm-simulators` itself as a row and never mentioned the HuggingFace artifact hop that actually connects LANfactory to HSSM. It now states this package's role in two sentences and links the complete map.
- `The HSSM ecosystem` added to the Home nav group, in the same position it occupies on the sibling sites, so the hub is one click from anywhere.

`mkdocs build --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the ecosystem description to clarify the simulator and data-generation role.
  * Added a link to the broader HSSM ecosystem overview.
  * Added the HSSM ecosystem overview to the documentation home navigation.
  * Simplified the ecosystem documentation by removing detailed package and integration information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->