### PR TITLE
Add native structured observation result validation

### DIFF
--- a/docs/api/basic_simulators.md
+++ b/docs/api/basic_simulators.md
@@ -1,1 +1,7 @@
-:::ssms.basic_simulators
+# Basic simulators API
+
+The package-native structured-observation validator is exported from
+`ssms.basic_simulators`. See the [contract reference](../reference/observation_result_contract.md)
+for its versioned schema and compatibility boundary.
+
+::: ssms.basic_simulators

--- a/docs/explanations/structured_observations.md
+++ b/docs/explanations/structured_observations.md
@@ -1,0 +1,74 @@
+# Why structured observation results exist
+
+Sequential-sampling models do not all produce the same kind of observation. The familiar
+case is reaction time plus a categorical choice, but a model may instead produce only a
+choice, a bounded confidence rating, several continuous measurements, a circular angle,
+or a fixed-width mixture of those fields.
+
+Historically, ssm-simulators has exposed `rts` and `choices`. Those arrays remain the
+default interface for existing simulators. They are heavily used by likelihood-estimation,
+training-data, HSSM, RLSSM, plotting, and external integration code, and this new contract
+does not silently migrate any of those consumers.
+
+The native structured-observation contract gives *new or explicitly opted-in producers*
+one general representation:
+
+```text
+observations[n_samples, n_trials, obs_dim]
+```
+
+The final axis is described by an ordered, versioned schema. Every stochastic scalar
+observation—including reaction time, when present—is treated symmetrically. A sidecar
+mask identifies complete omitted rows.
+
+## Observations are not every numeric output
+
+The schema contains only fields that are jointly observed and evaluated by a model's
+likelihood. It does not absorb auxiliary state merely because that state is numeric.
+Examples that remain outside the observation axis include:
+
+- simulated trajectories and time-varying boundaries;
+- participant and trial identifiers;
+- task context, feedback, and block labels;
+- latent reinforcement-learning values and computed trial parameters;
+- training labels and likelihood-density metadata.
+
+Those values remain in their existing result or open `metadata` locations. This boundary
+keeps a fixed-width observation vector useful without pretending that it can encode every
+kind of simulator output.
+
+## Why the shape is never squeezed
+
+Keeping all three axes makes singleton cases unambiguous. A response-only model with one
+sample and one trial has shape `(1, 1, 1)`, while an RT-plus-confidence model has shape
+`(1, 1, 2)`. Consumers do not need model-name rules or guesses about whether a singleton
+axis represented samples, trials, or observation fields.
+
+Legacy `rts` and `choices` may still use their historical squeezed shapes. Converting
+those results is a separate compatibility layer; the native validator does not guess how
+legacy arrays should be interpreted.
+
+## Why schema entries are closed but metadata is open
+
+Version 1 recognizes exactly three scalar-domain kinds: `categorical`, `continuous`, and
+`circular`. Each entry accepts only the keys defined for that kind, so a misspelled bound
+or an unsupported observation semantic fails immediately.
+
+The surrounding `metadata` mapping has the opposite policy. Only
+`observation_schema_version` and `observation_schema` are reserved. Producer-owned fields
+such as simulator identity, possible choices, parameters, timing limits, boundaries, and
+trajectories are accepted without interpretation and retain object identity in the
+validated shallow view.
+
+Adding unrelated producer metadata therefore does not require a schema-version change.
+Adding a new stochastic-observation semantic that version 1 cannot express does.
+
+## What version 1 deliberately does not represent
+
+Version 1 covers dense, fixed-width, floating NumPy arrays of scalar numeric fields and
+complete-row omissions. It does not claim support for ragged events, partial observation
+vectors, array-valued fields, string categories, simplex or unit-vector joint support, or
+continuous/mixed-response likelihood-estimation and LAN training.
+
+See the [normative result contract](../reference/observation_result_contract.md) for the
+exact schema, support, omission, and validation rules.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ models, and reinforcement-learning SSMs.
 | Training data generation | [Data generators](core_tutorials/tutorial_data_generators.ipynb), [dataset generator API](api/dataset_generators.md) |
 | RLSSM simulation | [RLSSM tutorial](core_tutorials/rlssm_tutorial.ipynb), [RLSSM API](api/rlssm.md) |
 | Choice-only RL models | [Choice-only RL tutorial](core_tutorials/choice_only_rl_models.ipynb), [RLSSM API](api/rlssm.md#choice-only-inverse-temperature-softmax-presets) |
+| Structured observation results | [Why structured observations exist](explanations/structured_observations.md), [result contract](reference/observation_result_contract.md) |
 | New model contributions | [Contribute new models](contributing/add_models.md), [parameter adapters](contributing/add_parameter_adapters.md) |
 
 ---
@@ -145,4 +146,5 @@ sudo apt-get install build-essential libgsl-dev
 - Generate LAN training data with the [data generator tutorial](core_tutorials/tutorial_data_generators.ipynb).
 - Build and simulate RLSSMs with the [RLSSM tutorial](core_tutorials/rlssm_tutorial.ipynb).
 - Learn response-only RL simulation in the [choice-only RL tutorial](core_tutorials/choice_only_rl_models.ipynb).
+- Understand native fixed-width outputs in [Why structured observations exist](explanations/structured_observations.md).
 - Use the [API reference](api/basic_simulators.md) when integrating ssms into another package.

--- a/docs/reference/observation_result_contract.md
+++ b/docs/reference/observation_result_contract.md
@@ -1,0 +1,127 @@
+# Structured observation result contract
+
+This page specifies observation schema version 1 and the behavior of
+`validate_observation_result`. It is the normative package contract for native
+fixed-width observation results.
+
+## Required result fields
+
+A native result is a mapping with three required keys:
+
+| Key | Required value |
+| --- | --- |
+| `observations` | floating NumPy array with shape `(n_samples, n_trials, obs_dim)` |
+| `omission_mask` | boolean NumPy array with shape `(n_samples, n_trials)` |
+| `metadata` | mapping containing the two reserved schema keys |
+
+The three observation axes are never squeezed. `obs_dim` must equal the number of ordered
+schema entries and must be at least one. Integer, complex, object, and structured
+observation dtypes are rejected; a floating dtype permits both numeric categorical labels
+and NaN omission rows.
+
+## Reserved metadata
+
+`metadata` must contain:
+
+```python
+{
+    "observation_schema_version": 1,
+    "observation_schema": (
+        # ordered schema entries
+    ),
+}
+```
+
+These are the only reserved metadata keys. Every other metadata key is producer-owned,
+accepted without interpretation, and retained in the returned shallow mapping. This
+includes fields such as `simulator`, `possible_choices`, parameter/configuration values,
+`max_t`, boundary information, and trajectories.
+
+The validator never inserts or overwrites reserved metadata. A future adapter that is
+given schema arguments must reject a conflicting pre-existing reserved value rather than
+silently replacing producer data.
+
+Unknown schema versions fail explicitly.
+
+## Version 1 schema entries
+
+`observation_schema` is a non-empty tuple of mappings. Its order defines the final
+observation axis. Every entry has a unique, non-empty string `name`, a supported `kind`,
+and no keys beyond those allowed for that kind.
+
+| Kind | Required keys | Optional keys | Support |
+| --- | --- | --- | --- |
+| `categorical` | `name`, `kind`, `values` | none | exact membership in finite, unique, integer-valued numeric labels |
+| `continuous` | `name`, `kind` | `lower`, `upper`, `lower_inclusive`, `upper_inclusive` | unbounded or one/two-sided scalar interval |
+| `circular` | `name`, `kind`, `lower`, `upper` | none | lower-inclusive, upper-exclusive interval `[lower, upper)` |
+
+Categorical booleans, strings, non-integral labels, infinities, and duplicate labels are
+invalid.
+
+Continuous endpoints must be finite when present. The corresponding inclusion flag is
+allowed only when its endpoint is present, must be boolean, and defaults to `True`.
+When both endpoints exist, `lower < upper`.
+
+Circular bounds must be finite and satisfy `lower < upper`. Their endpoint semantics are
+fixed; configurable inclusion flags are not part of version 1.
+
+Field names carry no hidden semantics. A field named `rt` is not required, moved, or
+validated differently from another positive continuous field.
+
+## Observation values
+
+Every non-omitted value must be finite and valid for its schema entry:
+
+- categorical values use exact numeric membership;
+- continuous values respect each declared endpoint and its inclusion flag;
+- circular values satisfy `lower <= value < upper`.
+
+The validator does not coerce, clip, wrap, reorder, or otherwise repair producer output.
+Schema order—not field-name convention—determines which domain applies to each column.
+
+## Complete-row omissions
+
+`omission_mask` is authoritative and must agree exactly with the observation array:
+
+- `False`: every field in the row is finite and domain-valid;
+- `True`: every field in the row is NaN;
+- a partially NaN row is invalid;
+- an all-NaN row with a false mask, or a finite row with a true mask, is invalid.
+
+The mask is a sidecar, not an observation field. This contract does not enable fitting
+missing observations or define a likelihood-level missing-data policy.
+
+## Validation result and purity
+
+```python
+from ssms.basic_simulators import validate_observation_result
+
+validated = validate_observation_result(result)
+```
+
+The function returns a plain dictionary. It shallow-copies the top-level result and its
+metadata mapping, while retaining the original observation array, mask array, schema, and
+producer-extension values. It never mutates the source.
+
+## Executable examples
+
+### RT plus bounded confidence
+
+```python
+--8<-- "docs/snippets/observation_results/rt_confidence.py"
+```
+
+### Response-only data with a complete omission
+
+```python
+--8<-- "docs/snippets/observation_results/response_only_omission.py"
+```
+
+The documentation test suite executes these exact files, including their assertions.
+
+## Compatibility boundary
+
+This validator does not adapt legacy `rts`/`choices`, attach schemas to registered
+simulators, modify `Simulator.simulate`, or migrate dataset, KDE, LAN, RLSSM, HSSM, or GUI
+consumers. Those changes require separate compatibility work. Existing simulator outputs
+remain unchanged by version 1 validation support.

--- a/docs/reference/observation_result_contract.md
+++ b/docs/reference/observation_result_contract.md
@@ -16,8 +16,8 @@ A native result is a mapping with three required keys:
 
 The three observation axes are never squeezed. `obs_dim` must equal the number of ordered
 schema entries and must be at least one. Integer, complex, object, and structured
-observation dtypes are rejected; a floating dtype permits both numeric categorical labels
-and NaN omission rows.
+observation dtypes are rejected; a floating dtype permits numeric categorical labels that
+it can represent exactly, together with NaN omission rows.
 
 ## Reserved metadata
 
@@ -51,12 +51,21 @@ and no keys beyond those allowed for that kind.
 
 | Kind | Required keys | Optional keys | Support |
 | --- | --- | --- | --- |
-| `categorical` | `name`, `kind`, `values` | none | exact membership in finite, unique, integer-valued numeric labels |
+| `categorical` | `name`, `kind`, `values` | none | exact membership in finite, unique, integer-valued numeric labels that are exactly representable in `observations.dtype` |
 | `continuous` | `name`, `kind` | `lower`, `upper`, `lower_inclusive`, `upper_inclusive` | unbounded or one/two-sided scalar interval |
 | `circular` | `name`, `kind`, `lower`, `upper` | none | lower-inclusive, upper-exclusive interval `[lower, upper)` |
 
 Categorical booleans, strings, non-integral labels, infinities, and duplicate labels are
-invalid.
+invalid. Every categorical label must also survive an exact round trip through the
+concrete floating `observations.dtype`. This dtype check runs even when the observation
+array is empty or every row is omitted, so schema compatibility never depends on which
+values happened to be simulated.
+
+Representability is checked label by label, not with a blanket magnitude limit. For
+example, `2**24 + 1` is not exactly representable in `float32`, while `2**24 + 2` is.
+Producers must select a wider dtype or different integer labels rather than relying on a
+lossy cast. This prevents a declared label from being rounded to a different stored value
+or colliding with another label after conversion.
 
 Continuous endpoints must be finite when present. The corresponding inclusion flag is
 allowed only when its endpoint is present, must be boolean, and defaults to `True`.
@@ -72,7 +81,8 @@ validated differently from another positive continuous field.
 
 Every non-omitted value must be finite and valid for its schema entry:
 
-- categorical values use exact numeric membership;
+- categorical values use exact numeric membership after the schema labels pass the
+  observation-dtype representability check;
 - continuous values respect each declared endpoint and its inclusion flag;
 - circular values satisfy `lower <= value < upper`.
 

--- a/docs/snippets/observation_results/response_only_omission.py
+++ b/docs/snippets/observation_results/response_only_omission.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from ssms.basic_simulators import validate_observation_result
+
+
+result = {
+    "observations": np.array([[[1.0], [np.nan], [2.0]]], dtype=np.float64),
+    "omission_mask": np.array([[False, True, False]], dtype=bool),
+    "metadata": {
+        "observation_schema_version": 1,
+        "observation_schema": (
+            {
+                "name": "response",
+                "kind": "categorical",
+                "values": (0, 1, 2),
+            },
+        ),
+        "simulator": "example_choice_only_model",
+    },
+}
+
+validated_result = validate_observation_result(result)
+
+assert validated_result["observations"].shape == (1, 3, 1)
+assert validated_result["omission_mask"].tolist() == [[False, True, False]]

--- a/docs/snippets/observation_results/rt_confidence.py
+++ b/docs/snippets/observation_results/rt_confidence.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+from ssms.basic_simulators import validate_observation_result
+
+
+boundary = np.linspace(1.0, 0.0, 100)
+result = {
+    "observations": np.array([[[0.42, 0.8], [0.71, 0.35]]], dtype=np.float64),
+    "omission_mask": np.array([[False, False]], dtype=bool),
+    "metadata": {
+        "observation_schema_version": 1,
+        "observation_schema": (
+            {
+                "name": "rt",
+                "kind": "continuous",
+                "lower": 0.0,
+                "lower_inclusive": False,
+            },
+            {
+                "name": "confidence",
+                "kind": "continuous",
+                "lower": 0.0,
+                "upper": 1.0,
+            },
+        ),
+        "simulator": "example_confidence_model",
+        "boundary": boundary,
+    },
+}
+
+validated_result = validate_observation_result(result)
+
+assert validated_result["observations"].shape == (1, 2, 2)
+assert validated_result["metadata"]["boundary"] is boundary

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,8 @@ repo_name: lnccbrown/ssm-simulators
 repo_url: https://github.com/lnccbrown/ssm-simulators
 site_url: https://lnccbrown.github.io/ssm-simulators
 edit_uri: edit/main/docs
+exclude_docs: |
+  snippets/
 
 nav:
   - Home:
@@ -23,8 +25,10 @@ nav:
   - Explanations:
       - What ssm-simulators can do: core_tutorials/tutorial_capabilities.ipynb
       - Simulation vs. analytical solutions (PyDDM): core_tutorials/tutorial_simulators_vs_pyddm.ipynb
+      - Why structured observations exist: explanations/structured_observations.md
   - Reference:
       - Configuration systems: core_tutorials/tutorial_configs.ipynb
+      - Structured observation results: reference/observation_result_contract.md
       - API:
           - RLSSM (ssms.rl): api/rlssm.md
           - basic simulators: api/basic_simulators.md

--- a/ssms/basic_simulators/__init__.py
+++ b/ssms/basic_simulators/__init__.py
@@ -1,15 +1,23 @@
-from . import boundary_functions
-from . import drift_functions
-from . import simulator
-from . import modular_parameter_simulator_adapter
-from .simulator_class import Simulator
+from . import (
+    boundary_functions,
+    drift_functions,
+    modular_parameter_simulator_adapter,
+    simulator,
+)
+from .observation_results import (
+    OBSERVATION_SCHEMA_VERSION,
+    validate_observation_result,
+)
 from .simulator import OMISSION_SENTINEL
+from .simulator_class import Simulator
 
 __all__ = [
+    "OBSERVATION_SCHEMA_VERSION",
+    "OMISSION_SENTINEL",
+    "Simulator",
     "boundary_functions",
     "drift_functions",
-    "simulator",
     "modular_parameter_simulator_adapter",
-    "Simulator",
-    "OMISSION_SENTINEL",
+    "simulator",
+    "validate_observation_result",
 ]

--- a/ssms/basic_simulators/observation_results.py
+++ b/ssms/basic_simulators/observation_results.py
@@ -6,7 +6,7 @@ This module defines only the package-native result contract. It does not adapt l
 
 from collections.abc import Mapping, Sequence
 import math
-from numbers import Real
+from numbers import Integral, Real
 from typing import Any
 
 import numpy as np
@@ -108,7 +108,7 @@ def validate_observation_result(result: Mapping[str, Any]) -> dict[str, Any]:
             f"{OBSERVATION_SCHEMA_VERSION}; got {version!r}"
         )
 
-    schema = _validate_schema(metadata["observation_schema"])
+    schema = _validate_schema(metadata["observation_schema"], observations.dtype)
     if observations.shape[-1] != len(schema):
         raise ValueError(
             "observations width must equal observation_schema length: "
@@ -123,7 +123,9 @@ def validate_observation_result(result: Mapping[str, Any]) -> dict[str, Any]:
     return validated
 
 
-def _validate_schema(schema: object) -> tuple[Mapping[str, Any], ...]:
+def _validate_schema(
+    schema: object, observation_dtype: np.dtype[Any]
+) -> tuple[Mapping[str, Any], ...]:
     if not isinstance(schema, tuple):
         raise TypeError("observation_schema must be an ordered tuple of mappings")
     if not schema:
@@ -163,7 +165,7 @@ def _validate_schema(schema: object) -> tuple[Mapping[str, Any], ...]:
             )
 
         if kind == "categorical":
-            _validate_categorical_schema(entry, name)
+            _validate_categorical_schema(entry, name, observation_dtype)
         elif kind == "continuous":
             _validate_continuous_schema(entry, name)
         else:
@@ -176,7 +178,9 @@ def _validate_schema(schema: object) -> tuple[Mapping[str, Any], ...]:
     return schema
 
 
-def _validate_categorical_schema(entry: Mapping[str, Any], name: str) -> None:
+def _validate_categorical_schema(
+    entry: Mapping[str, Any], name: str, observation_dtype: np.dtype[Any]
+) -> None:
     if "values" not in entry:
         raise ValueError(f"categorical field {name!r} requires values")
 
@@ -188,14 +192,20 @@ def _validate_categorical_schema(entry: Mapping[str, Any], name: str) -> None:
     if not values:
         raise ValueError(f"categorical field {name!r} values must not be empty")
 
-    validated_values: list[float] = []
+    validated_values: list[int] = []
     for value in values:
-        if not _is_finite_real(value) or not float(value).is_integer():
+        integer_value = _as_finite_integer(value)
+        if integer_value is None:
             raise ValueError(
                 f"categorical field {name!r} values must be finite, "
                 "integer-valued numeric labels"
             )
-        validated_values.append(float(value))
+        if not _integer_is_exactly_representable(integer_value, observation_dtype):
+            raise ValueError(
+                f"categorical field {name!r} value {value!r} is not exactly "
+                f"representable in observations dtype {observation_dtype.name}"
+            )
+        validated_values.append(integer_value)
 
     if len(validated_values) != len(set(validated_values)):
         raise ValueError(f"categorical field {name!r} values must be unique")
@@ -274,7 +284,8 @@ def _validate_observation_values(
         valid = np.ones(values.shape, dtype=bool)
 
         if kind == "categorical":
-            valid &= np.isin(values, tuple(entry["values"]))
+            categorical_values = np.asarray(entry["values"], dtype=observations.dtype)
+            valid &= np.isin(values, categorical_values)
         elif kind == "continuous":
             if "lower" in entry:
                 if entry.get("lower_inclusive", True):
@@ -299,11 +310,51 @@ def _validate_observation_values(
 
 
 def _is_finite_real(value: object) -> bool:
-    return (
-        not isinstance(value, (bool, np.bool_))
-        and isinstance(value, Real)
-        and math.isfinite(float(value))
-    )
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        return False
+    try:
+        return math.isfinite(value)
+    except (OverflowError, TypeError, ValueError):
+        return False
+
+
+def _as_finite_integer(value: object) -> int | None:
+    """Return the exact integer represented by a valid categorical label."""
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        return None
+    if isinstance(value, Integral):
+        return int(value)
+
+    as_integer_ratio = getattr(value, "as_integer_ratio", None)
+    if as_integer_ratio is not None:
+        try:
+            numerator, denominator = as_integer_ratio()
+        except (OverflowError, TypeError, ValueError):
+            return None
+        if denominator != 1:
+            return None
+        return int(numerator)
+
+    try:
+        as_float = float(value)
+        if not math.isfinite(as_float) or not as_float.is_integer():
+            return None
+        integer_value = int(as_float)
+    except (OverflowError, TypeError, ValueError):
+        return None
+    return integer_value if value == integer_value else None
+
+
+def _integer_is_exactly_representable(
+    value: int, observation_dtype: np.dtype[Any]
+) -> bool:
+    """Return whether ``value`` survives an exact round trip through ``dtype``."""
+    try:
+        with np.errstate(over="ignore", invalid="ignore"):
+            cast_value = np.asarray(value, dtype=observation_dtype)[()]
+    except (OverflowError, TypeError, ValueError):
+        return False
+    return bool(np.isfinite(cast_value)) and int(cast_value) == value
 
 
 def _format_keys(keys: Sequence[str] | set[str] | frozenset[str]) -> str:

--- a/ssms/basic_simulators/observation_results.py
+++ b/ssms/basic_simulators/observation_results.py
@@ -1,0 +1,313 @@
+"""Validation for native fixed-width simulator observation results.
+
+This module defines only the package-native result contract. It does not adapt legacy
+``rts``/``choices`` results or attach schemas to registered simulators.
+"""
+
+from collections.abc import Mapping, Sequence
+import math
+from numbers import Real
+from typing import Any
+
+import numpy as np
+
+OBSERVATION_SCHEMA_VERSION = 1
+
+_REQUIRED_RESULT_KEYS = frozenset({"observations", "omission_mask", "metadata"})
+_RESERVED_METADATA_KEYS = frozenset(
+    {"observation_schema_version", "observation_schema"}
+)
+_COMMON_SCHEMA_KEYS = frozenset({"name", "kind"})
+_SCHEMA_KEYS_BY_KIND = {
+    "categorical": _COMMON_SCHEMA_KEYS | {"values"},
+    "continuous": _COMMON_SCHEMA_KEYS
+    | {"lower", "upper", "lower_inclusive", "upper_inclusive"},
+    "circular": _COMMON_SCHEMA_KEYS | {"lower", "upper"},
+}
+
+
+def validate_observation_result(result: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate a native fixed-width simulator observation result.
+
+    Parameters
+    ----------
+    result
+        Mapping with ``observations``, ``omission_mask``, and ``metadata``. The
+        observations must be a floating NumPy array with shape
+        ``(n_samples, n_trials, obs_dim)``. Metadata must contain the versioned,
+        ordered ``observation_schema``.
+
+    Returns
+    -------
+    dict
+        A shallow plain-dictionary view of the validated result. Observation and mask
+        arrays are not copied. Metadata is shallow-copied, so producer-owned extension
+        values retain identity.
+
+    Raises
+    ------
+    TypeError
+        If the result, arrays, metadata, or schema entries use invalid container or
+        dtype types.
+    ValueError
+        If required fields, schema definitions, shapes, omission encodings, or
+        observation values violate the contract.
+
+    Notes
+    -----
+    Validation is pure: the source mapping, arrays, schema, and metadata values are
+    never mutated. Metadata keys other than ``observation_schema_version`` and
+    ``observation_schema`` are producer-owned extensions and are not interpreted.
+    """
+    if not isinstance(result, Mapping):
+        raise TypeError("observation result must be a mapping")
+
+    missing_result_keys = _REQUIRED_RESULT_KEYS.difference(result)
+    if missing_result_keys:
+        raise ValueError(
+            "observation result is missing required key(s): "
+            f"{_format_keys(missing_result_keys)}"
+        )
+
+    observations = result["observations"]
+    omission_mask = result["omission_mask"]
+    metadata = result["metadata"]
+
+    if not isinstance(observations, np.ndarray):
+        raise TypeError("observations must be a NumPy array")
+    if observations.ndim != 3:
+        raise ValueError(
+            "observations must have exactly three axes (n_samples, n_trials, obs_dim)"
+        )
+    if not np.issubdtype(observations.dtype, np.floating):
+        raise TypeError("observations must have a floating NumPy dtype")
+
+    if not isinstance(omission_mask, np.ndarray):
+        raise TypeError("omission_mask must be a NumPy array")
+    if not np.issubdtype(omission_mask.dtype, np.bool_):
+        raise TypeError("omission_mask must have a boolean NumPy dtype")
+    if omission_mask.shape != observations.shape[:2]:
+        raise ValueError(
+            "omission_mask shape must equal the first two observation axes: "
+            f"expected {observations.shape[:2]}, got {omission_mask.shape}"
+        )
+
+    if not isinstance(metadata, Mapping):
+        raise TypeError("metadata must be a mapping")
+    missing_metadata_keys = _RESERVED_METADATA_KEYS.difference(metadata)
+    if missing_metadata_keys:
+        raise ValueError(
+            "metadata is missing required reserved key(s): "
+            f"{_format_keys(missing_metadata_keys)}"
+        )
+
+    version = metadata["observation_schema_version"]
+    if type(version) is not int or version != OBSERVATION_SCHEMA_VERSION:
+        raise ValueError(
+            "observation_schema_version must be the supported integer version "
+            f"{OBSERVATION_SCHEMA_VERSION}; got {version!r}"
+        )
+
+    schema = _validate_schema(metadata["observation_schema"])
+    if observations.shape[-1] != len(schema):
+        raise ValueError(
+            "observations width must equal observation_schema length: "
+            f"expected {len(schema)}, got {observations.shape[-1]}"
+        )
+
+    _validate_omissions(observations, omission_mask)
+    _validate_observation_values(observations, omission_mask, schema)
+
+    validated = dict(result)
+    validated["metadata"] = dict(metadata)
+    return validated
+
+
+def _validate_schema(schema: object) -> tuple[Mapping[str, Any], ...]:
+    if not isinstance(schema, tuple):
+        raise TypeError("observation_schema must be an ordered tuple of mappings")
+    if not schema:
+        raise ValueError("observation_schema must contain at least one field")
+
+    names: list[str] = []
+    for index, entry in enumerate(schema):
+        if not isinstance(entry, Mapping):
+            raise TypeError(f"observation_schema entry {index} must be a mapping")
+
+        missing_common = _COMMON_SCHEMA_KEYS.difference(entry)
+        if missing_common:
+            raise ValueError(
+                f"observation_schema entry {index} is missing required key(s): "
+                f"{_format_keys(missing_common)}"
+            )
+
+        name = entry["name"]
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(
+                f"observation_schema entry {index} name must be a non-empty string"
+            )
+
+        kind = entry["kind"]
+        if kind not in _SCHEMA_KEYS_BY_KIND:
+            raise ValueError(
+                f"observation_schema entry {name!r} kind must be one of "
+                f"{tuple(_SCHEMA_KEYS_BY_KIND)}; got {kind!r}"
+            )
+
+        allowed_keys = _SCHEMA_KEYS_BY_KIND[kind]
+        unexpected_keys = set(entry).difference(allowed_keys)
+        if unexpected_keys:
+            raise ValueError(
+                f"observation_schema entry {name!r} has unsupported key(s): "
+                f"{_format_keys(unexpected_keys)}"
+            )
+
+        if kind == "categorical":
+            _validate_categorical_schema(entry, name)
+        elif kind == "continuous":
+            _validate_continuous_schema(entry, name)
+        else:
+            _validate_circular_schema(entry, name)
+
+        names.append(name)
+
+    if len(names) != len(set(names)):
+        raise ValueError("observation_schema field names must be unique")
+    return schema
+
+
+def _validate_categorical_schema(entry: Mapping[str, Any], name: str) -> None:
+    if "values" not in entry:
+        raise ValueError(f"categorical field {name!r} requires values")
+
+    values = entry["values"]
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise TypeError(
+            f"categorical field {name!r} values must be a non-empty sequence"
+        )
+    if not values:
+        raise ValueError(f"categorical field {name!r} values must not be empty")
+
+    validated_values: list[float] = []
+    for value in values:
+        if not _is_finite_real(value) or not float(value).is_integer():
+            raise ValueError(
+                f"categorical field {name!r} values must be finite, "
+                "integer-valued numeric labels"
+            )
+        validated_values.append(float(value))
+
+    if len(validated_values) != len(set(validated_values)):
+        raise ValueError(f"categorical field {name!r} values must be unique")
+
+
+def _validate_continuous_schema(entry: Mapping[str, Any], name: str) -> None:
+    for endpoint in ("lower", "upper"):
+        inclusive = f"{endpoint}_inclusive"
+        if endpoint not in entry:
+            if inclusive in entry:
+                raise ValueError(
+                    f"continuous field {name!r} cannot define {inclusive} "
+                    f"without {endpoint}"
+                )
+            continue
+
+        if not _is_finite_real(entry[endpoint]):
+            raise ValueError(
+                f"continuous field {name!r} {endpoint} must be a finite number"
+            )
+        if inclusive in entry and type(entry[inclusive]) is not bool:
+            raise ValueError(f"continuous field {name!r} {inclusive} must be boolean")
+
+    if (
+        "lower" in entry
+        and "upper" in entry
+        and float(entry["lower"]) >= float(entry["upper"])
+    ):
+        raise ValueError(f"continuous field {name!r} lower must be less than upper")
+
+
+def _validate_circular_schema(entry: Mapping[str, Any], name: str) -> None:
+    missing = {"lower", "upper"}.difference(entry)
+    if missing:
+        raise ValueError(
+            f"circular field {name!r} is missing required key(s): "
+            f"{_format_keys(missing)}"
+        )
+    if not _is_finite_real(entry["lower"]) or not _is_finite_real(entry["upper"]):
+        raise ValueError(f"circular field {name!r} bounds must be finite numbers")
+    if float(entry["lower"]) >= float(entry["upper"]):
+        raise ValueError(f"circular field {name!r} lower must be less than upper")
+
+
+def _validate_omissions(observations: np.ndarray, omission_mask: np.ndarray) -> None:
+    nan_components = np.isnan(observations)
+    any_nan = np.any(nan_components, axis=-1)
+    all_nan = np.all(nan_components, axis=-1)
+    if np.any(any_nan & ~all_nan):
+        raise ValueError(
+            "partial-NaN observation rows are invalid; omissions must cover every field"
+        )
+    if not np.array_equal(omission_mask, all_nan):
+        raise ValueError(
+            "omission_mask must exactly equal the rows whose observation fields are "
+            "all NaN"
+        )
+
+    available = observations[~omission_mask]
+    if not np.all(np.isfinite(available)):
+        raise ValueError("non-omitted observation values must be finite")
+
+
+def _validate_observation_values(
+    observations: np.ndarray,
+    omission_mask: np.ndarray,
+    schema: tuple[Mapping[str, Any], ...],
+) -> None:
+    for index, entry in enumerate(schema):
+        values = observations[..., index][~omission_mask]
+        if values.size == 0:
+            continue
+
+        name = entry["name"]
+        kind = entry["kind"]
+        valid = np.ones(values.shape, dtype=bool)
+
+        if kind == "categorical":
+            valid &= np.isin(values, tuple(entry["values"]))
+        elif kind == "continuous":
+            if "lower" in entry:
+                if entry.get("lower_inclusive", True):
+                    valid &= values >= entry["lower"]
+                else:
+                    valid &= values > entry["lower"]
+            if "upper" in entry:
+                if entry.get("upper_inclusive", True):
+                    valid &= values <= entry["upper"]
+                else:
+                    valid &= values < entry["upper"]
+        else:
+            valid &= values >= entry["lower"]
+            valid &= values < entry["upper"]
+
+        if not np.all(valid):
+            invalid_values = np.unique(values[~valid])
+            raise ValueError(
+                f"observation field {name!r} contains value(s) outside its "
+                f"{kind} domain: {invalid_values.tolist()}"
+            )
+
+
+def _is_finite_real(value: object) -> bool:
+    return (
+        not isinstance(value, (bool, np.bool_))
+        and isinstance(value, Real)
+        and math.isfinite(float(value))
+    )
+
+
+def _format_keys(keys: Sequence[str] | set[str] | frozenset[str]) -> str:
+    return ", ".join(repr(key) for key in sorted(keys))
+
+
+__all__ = ["OBSERVATION_SCHEMA_VERSION", "validate_observation_result"]

--- a/tests/test_observation_result_docs.py
+++ b/tests/test_observation_result_docs.py
@@ -1,0 +1,26 @@
+"""Execute the structured-observation examples published in the documentation."""
+
+from pathlib import Path
+import runpy
+
+import pytest
+
+
+SNIPPET_DIR = (
+    Path(__file__).resolve().parents[1] / "docs" / "snippets" / "observation_results"
+)
+SNIPPETS = tuple(sorted(SNIPPET_DIR.glob("*.py")))
+
+
+def test_structured_observation_snippet_set_is_explicit() -> None:
+    assert tuple(path.name for path in SNIPPETS) == (
+        "response_only_omission.py",
+        "rt_confidence.py",
+    )
+
+
+@pytest.mark.parametrize("snippet", SNIPPETS, ids=lambda path: path.stem)
+def test_structured_observation_snippet_executes(snippet: Path) -> None:
+    namespace = runpy.run_path(str(snippet))
+
+    assert namespace["validated_result"]["observations"].ndim == 3

--- a/tests/test_observation_results.py
+++ b/tests/test_observation_results.py
@@ -6,17 +6,10 @@ from typing import Any
 import numpy as np
 import pytest
 
-pytestmark = pytest.mark.xfail(
-    strict=True,
-    raises=ImportError,
-    reason="The native observation-result validator is introduced in the next commit.",
-)
-
-
 Schema = tuple[Mapping[str, Any], ...]
 
 
-def _validate(result: Mapping[str, Any]) -> dict[str, Any]:
+def _validate(result: Any) -> dict[str, Any]:
     from ssms.basic_simulators import validate_observation_result
 
     return validate_observation_result(result)
@@ -171,6 +164,7 @@ def test_validate_observation_result_rejects_unknown_or_non_integer_versions(
             ),
             "unique",
         ),
+        (({"name": "x"},), "kind"),
         (({"name": "x", "kind": "unknown"},), "kind"),
         (({"name": "x", "kind": "continuous", "typo": 1.0},), "typo"),
         (({"name": "x", "kind": "categorical"},), "values"),
@@ -364,6 +358,123 @@ def test_validate_observation_result_rejects_invalid_array_contracts(
 
     with pytest.raises((TypeError, ValueError), match=message):
         _validate(result)
+
+
+@pytest.mark.parametrize(
+    ("result", "message"),
+    [
+        ([], "mapping"),
+        ({"metadata": {}}, "missing required"),
+        (
+            {
+                "observations": [[[0.5]]],
+                "omission_mask": np.zeros((1, 1), dtype=bool),
+                "metadata": {
+                    "observation_schema_version": 1,
+                    "observation_schema": (RT,),
+                },
+            },
+            "NumPy array",
+        ),
+        (
+            {
+                "observations": np.asarray([[[0.5]]]),
+                "omission_mask": [[False]],
+                "metadata": {
+                    "observation_schema_version": 1,
+                    "observation_schema": (RT,),
+                },
+            },
+            "NumPy array",
+        ),
+        (
+            {
+                "observations": np.asarray([[[0.5]]]),
+                "omission_mask": np.zeros((1, 1), dtype=bool),
+                "metadata": [],
+            },
+            "metadata must be a mapping",
+        ),
+        (
+            {
+                "observations": np.asarray([[[0.5]]]),
+                "omission_mask": np.zeros((1, 1), dtype=bool),
+                "metadata": {
+                    "observation_schema_version": 1,
+                    "observation_schema": [RT],
+                },
+            },
+            "ordered tuple",
+        ),
+        (
+            {
+                "observations": np.asarray([[[0.5]]]),
+                "omission_mask": np.zeros((1, 1), dtype=bool),
+                "metadata": {
+                    "observation_schema_version": 1,
+                    "observation_schema": ("rt",),
+                },
+            },
+            "entry 0 must be a mapping",
+        ),
+        (
+            {
+                "observations": np.asarray([[[0.5, 0.6]]]),
+                "omission_mask": np.zeros((1, 1), dtype=bool),
+                "metadata": {
+                    "observation_schema_version": 1,
+                    "observation_schema": (RT,),
+                },
+            },
+            "width",
+        ),
+        (
+            {
+                "observations": np.asarray([[[0.0]]]),
+                "omission_mask": np.zeros((1, 1), dtype=bool),
+                "metadata": {
+                    "observation_schema_version": 1,
+                    "observation_schema": (
+                        {"name": "choice", "kind": "categorical", "values": "01"},
+                    ),
+                },
+            },
+            "non-empty sequence",
+        ),
+    ],
+)
+def test_validate_observation_result_rejects_invalid_container_contracts(
+    result: object,
+    message: str,
+) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        _validate(result)
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"name": "angle", "kind": "circular", "lower": -np.inf, "upper": np.pi},
+        {"name": "angle", "kind": "circular", "lower": 1.0, "upper": 1.0},
+    ],
+)
+def test_validate_observation_result_rejects_invalid_circular_domains(
+    entry: Mapping[str, Any],
+) -> None:
+    with pytest.raises(ValueError, match="circular"):
+        _validate(_result((entry,), [[[0.0]]]))
+
+
+def test_validate_observation_result_accepts_an_all_omitted_batch() -> None:
+    result = _result(
+        (RT, CHOICE),
+        [[[np.nan, np.nan], [np.nan, np.nan]]],
+        omission_mask=[[True, True]],
+    )
+
+    validated = _validate(result)
+
+    assert validated["omission_mask"].all()
 
 
 def test_validate_observation_result_preserves_open_metadata_without_mutation() -> None:

--- a/tests/test_observation_results.py
+++ b/tests/test_observation_results.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 import pytest
 
 Schema = tuple[Mapping[str, Any], ...]
@@ -19,12 +20,15 @@ def _result(
     schema: Schema,
     observations: Sequence[Sequence[Sequence[float]]],
     *,
+    dtype: npt.DTypeLike = np.float64,
     omission_mask: Sequence[Sequence[bool]] | None = None,
     metadata: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    observation_array = np.asarray(observations, dtype=np.float64)
+    observation_array = np.asarray(observations, dtype=dtype)
     if omission_mask is None:
-        omission_mask = np.zeros(observation_array.shape[:2], dtype=bool)
+        omission_array = np.zeros(observation_array.shape[:2], dtype=bool)
+    else:
+        omission_array = np.asarray(omission_mask, dtype=bool)
 
     result_metadata = dict(metadata or {})
     result_metadata.update(
@@ -35,7 +39,7 @@ def _result(
     )
     return {
         "observations": observation_array,
-        "omission_mask": np.asarray(omission_mask, dtype=bool),
+        "omission_mask": omission_array,
         "metadata": result_metadata,
     }
 
@@ -267,6 +271,82 @@ def test_validate_observation_result_rejects_invalid_categorical_labels(
 
     with pytest.raises(ValueError, match="values"):
         _validate(_result((entry,), [[[0.0]]]))
+
+
+@pytest.mark.parametrize(
+    ("dtype", "label"),
+    [
+        (np.float16, 2**11 + 1),
+        (np.float32, 2**24 + 1),
+        (np.float64, 2**53 + 1),
+    ],
+    ids=("float16", "float32", "float64"),
+)
+@pytest.mark.parametrize("batch", ["non-omitted", "all-omitted", "empty"])
+def test_validate_observation_result_rejects_categorical_labels_not_exactly_representable(
+    dtype: npt.DTypeLike,
+    label: int,
+    batch: str,
+) -> None:
+    if batch == "non-omitted":
+        observations = np.asarray([[[label]]], dtype=dtype)
+        omission_mask = np.zeros((1, 1), dtype=bool)
+    elif batch == "all-omitted":
+        observations = np.full((1, 1, 1), np.nan, dtype=dtype)
+        omission_mask = np.ones((1, 1), dtype=bool)
+    else:
+        observations = np.empty((0, 1, 1), dtype=dtype)
+        omission_mask = np.empty((0, 1), dtype=bool)
+
+    result = {
+        "observations": observations,
+        "omission_mask": omission_mask,
+        "metadata": {
+            "observation_schema_version": 1,
+            "observation_schema": (
+                {"name": "choice", "kind": "categorical", "values": (label,)},
+            ),
+        },
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=rf"choice.*not exactly representable.*{np.dtype(dtype).name}",
+    ):
+        _validate(result)
+
+
+@pytest.mark.parametrize("label", [10**1000, -(10**1000)], ids=("positive", "negative"))
+def test_validate_observation_result_rejects_categorical_labels_too_large_for_dtype(
+    label: int,
+) -> None:
+    entry = {"name": "choice", "kind": "categorical", "values": (label,)}
+
+    with pytest.raises(ValueError, match="not exactly representable.*float64"):
+        _validate(_result((entry,), [[[0.0]]]))
+
+
+@pytest.mark.parametrize(
+    ("dtype", "label"),
+    [
+        (np.float16, 2**11 + 2),
+        (np.float32, 2**24 + 2),
+        (np.float64, 2**53 + 2),
+    ],
+    ids=("float16", "float32", "float64"),
+)
+def test_validate_observation_result_accepts_large_exactly_representable_categorical_labels(
+    dtype: npt.DTypeLike,
+    label: int,
+) -> None:
+    entry = {"name": "choice", "kind": "categorical", "values": (-label, label)}
+    result = _result((entry,), [[[-label], [label]]], dtype=dtype)
+
+    validated = _validate(result)
+
+    np.testing.assert_array_equal(
+        validated["observations"], np.asarray([[[-label], [label]]], dtype=dtype)
+    )
 
 
 def test_validate_observation_result_enforces_categorical_membership() -> None:

--- a/tests/test_observation_results.py
+++ b/tests/test_observation_results.py
@@ -1,0 +1,390 @@
+"""Contract tests for native structured-observation simulator results."""
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.xfail(
+    strict=True,
+    raises=ImportError,
+    reason="The native observation-result validator is introduced in the next commit.",
+)
+
+
+Schema = tuple[Mapping[str, Any], ...]
+
+
+def _validate(result: Mapping[str, Any]) -> dict[str, Any]:
+    from ssms.basic_simulators import validate_observation_result
+
+    return validate_observation_result(result)
+
+
+def _result(
+    schema: Schema,
+    observations: Sequence[Sequence[Sequence[float]]],
+    *,
+    omission_mask: Sequence[Sequence[bool]] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    observation_array = np.asarray(observations, dtype=np.float64)
+    if omission_mask is None:
+        omission_mask = np.zeros(observation_array.shape[:2], dtype=bool)
+
+    result_metadata = dict(metadata or {})
+    result_metadata.update(
+        {
+            "observation_schema_version": 1,
+            "observation_schema": schema,
+        }
+    )
+    return {
+        "observations": observation_array,
+        "omission_mask": np.asarray(omission_mask, dtype=bool),
+        "metadata": result_metadata,
+    }
+
+
+RT = {
+    "name": "rt",
+    "kind": "continuous",
+    "lower": 0.0,
+    "lower_inclusive": False,
+}
+CHOICE = {"name": "response", "kind": "categorical", "values": (-1, 1)}
+CONFIDENCE = {
+    "name": "confidence",
+    "kind": "continuous",
+    "lower": 0.0,
+    "upper": 1.0,
+}
+AZIMUTH = {
+    "name": "azimuth",
+    "kind": "circular",
+    "lower": -np.pi,
+    "upper": np.pi,
+}
+
+
+@pytest.mark.parametrize(
+    ("schema", "observations"),
+    [
+        ((CHOICE,), [[[1.0], [-1.0]]]),
+        ((RT, CHOICE), [[[0.3, -1.0], [0.8, 1.0]]]),
+        (
+            (
+                {"name": "latency", "kind": "continuous"},
+                {"name": "force", "kind": "continuous", "lower": 0.0},
+                CONFIDENCE,
+            ),
+            [[[1.2, 3.4, 0.25]]],
+        ),
+        (
+            (
+                RT,
+                {"name": "polar", "kind": "continuous", "lower": 0.0, "upper": np.pi},
+                AZIMUTH,
+                {"name": "endpoint", "kind": "continuous"},
+            ),
+            [[[0.4, 1.2, -2.2, 7.5]]],
+        ),
+    ],
+    ids=(
+        "response-only-categorical",
+        "rt-and-categorical",
+        "three-continuous-measurements",
+        "four-mixed-observations",
+    ),
+)
+def test_validate_observation_result_accepts_generic_one_to_four_field_schemas(
+    schema: Schema,
+    observations: Sequence[Sequence[Sequence[float]]],
+) -> None:
+    result = _result(schema, observations)
+
+    validated = _validate(result)
+
+    assert validated["observations"] is result["observations"]
+    assert validated["omission_mask"] is result["omission_mask"]
+    assert tuple(entry["name"] for entry in schema) == tuple(
+        entry["name"] for entry in validated["metadata"]["observation_schema"]
+    )
+    assert validated["observations"].shape[-1] == len(schema)
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        (RT, {"name": "response", "kind": "categorical", "values": (0, 1, 2, 3)}),
+        ({"name": "response", "kind": "categorical", "values": (0, 1, 2)},),
+    ],
+    ids=("rt-based-rlssm", "choice-only-rlssm"),
+)
+def test_validate_observation_result_accepts_existing_rlssm_observation_shapes(
+    schema: Schema,
+) -> None:
+    observations = [[[0.5, 2.0]]] if len(schema) == 2 else [[[2.0]]]
+
+    validated = _validate(_result(schema, observations))
+
+    assert tuple(
+        item["name"] for item in validated["metadata"]["observation_schema"]
+    ) == tuple(item["name"] for item in schema)
+
+
+@pytest.mark.parametrize(
+    "missing_key",
+    ["observation_schema_version", "observation_schema"],
+)
+def test_validate_observation_result_requires_reserved_metadata(
+    missing_key: str,
+) -> None:
+    result = _result((RT,), [[[0.5]]])
+    del result["metadata"][missing_key]
+
+    with pytest.raises(ValueError, match=missing_key):
+        _validate(result)
+
+
+@pytest.mark.parametrize("version", [0, 2, True, "1"])
+def test_validate_observation_result_rejects_unknown_or_non_integer_versions(
+    version: object,
+) -> None:
+    result = _result((RT,), [[[0.5]]])
+    result["metadata"]["observation_schema_version"] = version
+
+    with pytest.raises(ValueError, match="observation_schema_version"):
+        _validate(result)
+
+
+@pytest.mark.parametrize(
+    ("schema", "message"),
+    [
+        ((), "at least one"),
+        (({"name": "", "kind": "continuous"},), "name"),
+        (
+            (
+                {"name": "same", "kind": "continuous"},
+                {"name": "same", "kind": "continuous"},
+            ),
+            "unique",
+        ),
+        (({"name": "x", "kind": "unknown"},), "kind"),
+        (({"name": "x", "kind": "continuous", "typo": 1.0},), "typo"),
+        (({"name": "x", "kind": "categorical"},), "values"),
+        (({"name": "x", "kind": "circular", "lower": 0.0},), "upper"),
+    ],
+)
+def test_validate_observation_result_rejects_invalid_schema_entries(
+    schema: Schema,
+    message: str,
+) -> None:
+    observations = np.zeros((1, 1, max(len(schema), 1)), dtype=np.float64)
+    result = {
+        "observations": observations,
+        "omission_mask": np.zeros((1, 1), dtype=bool),
+        "metadata": {
+            "observation_schema_version": 1,
+            "observation_schema": schema,
+        },
+    }
+
+    with pytest.raises(ValueError, match=message):
+        _validate(result)
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"name": "x", "kind": "continuous", "lower": np.inf},
+        {"name": "x", "kind": "continuous", "lower_inclusive": False},
+        {
+            "name": "x",
+            "kind": "continuous",
+            "lower": 1.0,
+            "upper": 1.0,
+        },
+        {
+            "name": "x",
+            "kind": "continuous",
+            "lower": 0.0,
+            "lower_inclusive": 1,
+        },
+    ],
+)
+def test_validate_observation_result_rejects_invalid_continuous_domains(
+    entry: Mapping[str, Any],
+) -> None:
+    with pytest.raises(ValueError, match="continuous|lower|upper|inclusive"):
+        _validate(_result((entry,), [[[0.5]]]))
+
+
+@pytest.mark.parametrize(
+    ("entry", "value", "valid"),
+    [
+        ({"name": "x", "kind": "continuous", "lower": 0.0}, 0.0, True),
+        (
+            {
+                "name": "x",
+                "kind": "continuous",
+                "lower": 0.0,
+                "lower_inclusive": False,
+            },
+            0.0,
+            False,
+        ),
+        ({"name": "x", "kind": "continuous", "upper": 1.0}, 1.0, True),
+        (
+            {
+                "name": "x",
+                "kind": "continuous",
+                "upper": 1.0,
+                "upper_inclusive": False,
+            },
+            1.0,
+            False,
+        ),
+    ],
+)
+def test_validate_observation_result_enforces_continuous_endpoint_inclusion(
+    entry: Mapping[str, Any],
+    value: float,
+    valid: bool,
+) -> None:
+    result = _result((entry,), [[[value]]])
+
+    if valid:
+        assert _validate(result)["observations"] is result["observations"]
+    else:
+        with pytest.raises(ValueError, match="x"):
+            _validate(result)
+
+
+@pytest.mark.parametrize(
+    "values",
+    [(), (True, False), (0.5, 1.0), (0.0, np.inf), (0, 0)],
+)
+def test_validate_observation_result_rejects_invalid_categorical_labels(
+    values: Sequence[object],
+) -> None:
+    entry = {"name": "choice", "kind": "categorical", "values": values}
+
+    with pytest.raises(ValueError, match="values"):
+        _validate(_result((entry,), [[[0.0]]]))
+
+
+def test_validate_observation_result_enforces_categorical_membership() -> None:
+    with pytest.raises(ValueError, match="choice"):
+        _validate(
+            _result(
+                ({"name": "choice", "kind": "categorical", "values": (-1, 1)},),
+                [[[0.0]]],
+            )
+        )
+
+
+@pytest.mark.parametrize("value", [-np.pi, 0.0, np.nextafter(np.pi, -np.inf)])
+def test_validate_observation_result_accepts_circular_half_open_support(
+    value: float,
+) -> None:
+    assert _validate(_result((AZIMUTH,), [[[value]]]))["observations"].shape == (
+        1,
+        1,
+        1,
+    )
+
+
+@pytest.mark.parametrize("value", [np.pi, -np.pi - 0.1])
+def test_validate_observation_result_rejects_values_outside_circular_support(
+    value: float,
+) -> None:
+    with pytest.raises(ValueError, match="azimuth"):
+        _validate(_result((AZIMUTH,), [[[value]]]))
+
+
+@pytest.mark.parametrize(
+    ("observations", "mask", "message"),
+    [
+        ([[[np.nan, 1.0]]], [[True]], "partial"),
+        ([[[np.nan, np.nan]]], [[False]], "omission_mask"),
+        ([[[0.5, 1.0]]], [[True]], "omission_mask"),
+        ([[[np.inf, 1.0]]], [[False]], "finite"),
+    ],
+)
+def test_validate_observation_result_requires_exact_complete_row_omissions(
+    observations: Sequence[Sequence[Sequence[float]]],
+    mask: Sequence[Sequence[bool]],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        _validate(_result((RT, CHOICE), observations, omission_mask=mask))
+
+
+def test_validate_observation_result_accepts_complete_row_omissions() -> None:
+    result = _result(
+        (RT, CHOICE),
+        [[[0.4, 1.0], [np.nan, np.nan]]],
+        omission_mask=[[False, True]],
+    )
+
+    validated = _validate(result)
+
+    np.testing.assert_array_equal(validated["omission_mask"], [[False, True]])
+    assert np.isnan(validated["observations"][0, 1]).all()
+
+
+@pytest.mark.parametrize(
+    ("observations", "mask", "message"),
+    [
+        (np.zeros((2, 1), dtype=np.float64), np.zeros((2,), dtype=bool), "three"),
+        (np.zeros((1, 1, 1), dtype=np.int64), np.zeros((1, 1), dtype=bool), "floating"),
+        (
+            np.zeros((1, 1, 1), dtype=np.float64),
+            np.zeros((1, 1), dtype=np.int64),
+            "boolean",
+        ),
+        (np.zeros((1, 2, 1), dtype=np.float64), np.zeros((2, 1), dtype=bool), "shape"),
+    ],
+)
+def test_validate_observation_result_rejects_invalid_array_contracts(
+    observations: np.ndarray,
+    mask: np.ndarray,
+    message: str,
+) -> None:
+    result = {
+        "observations": observations,
+        "omission_mask": mask,
+        "metadata": {
+            "observation_schema_version": 1,
+            "observation_schema": (RT,),
+        },
+    }
+
+    with pytest.raises((TypeError, ValueError), match=message):
+        _validate(result)
+
+
+def test_validate_observation_result_preserves_open_metadata_without_mutation() -> None:
+    boundary = np.linspace(0.0, 1.0, 1000)
+    trajectory = {"x": np.arange(10.0)}
+    metadata = {
+        "simulator": "future_model",
+        "possible_choices": (-1, 1),
+        "boundary": boundary,
+        "trajectory": trajectory,
+    }
+    result = _result((RT, CHOICE), [[[0.4, 1.0]]], metadata=metadata)
+    source_keys = tuple(result["metadata"])
+
+    validated = _validate(result)
+
+    assert type(validated) is dict
+    assert type(validated["metadata"]) is dict
+    assert validated is not result
+    assert validated["metadata"] is not result["metadata"]
+    assert tuple(result["metadata"]) == source_keys
+    assert validated["metadata"]["boundary"] is boundary
+    assert validated["metadata"]["trajectory"] is trajectory
+    assert validated["metadata"]["possible_choices"] == (-1, 1)


### PR DESCRIPTION
## Summary

- add a package-native, opt-in validator for fixed-width structured observation results
- define schema version 1 for ordered categorical, continuous, and circular scalar fields
- require unsqueezed `(n_samples, n_trials, obs_dim)` observations and an exact complete-row omission mask
- keep the surrounding metadata mapping open so simulator configuration, trajectories, RL state, and future producer extensions remain intact
- require every categorical label to be exactly representable in the concrete floating observation dtype
- document the contract as both an explanation and a normative reference, with executable examples

## Why categorical dtype validation is part of the contract

Floating arrays cannot represent every integer label exactly. For example, `2**53 + 1` rounds when stored in `float64`; testing membership only after that cast can accept a different value than the schema declares. The validator now normalizes labels as exact integers and round-trips each one through `observations.dtype` before checking observations.

This validation runs for populated, all-omitted, and empty batches, so schema compatibility does not depend on which values happened to be simulated. Representable sparse labels remain valid: `2**24 + 2` is accepted in `float32`, while `2**24 + 1` is rejected.

## Compatibility boundary

This PR does not change any existing simulator output, `Simulator.simulate`, the model registry, dataset/KDE/LAN paths, RLSSM output, HSSM adapters, GUI consumers, or Cython code. Existing `rts`/`choices` consumers continue unchanged.

The validator is functional and pure: it shallow-copies the result and metadata mappings, preserves arrays and extension objects by identity, and never coerces, clips, wraps, reorders, or mutates producer output. Metadata keys outside the two reserved schema keys remain producer-owned and open-ended.

## Validation

- base PR full default suite before the review follow-up: 1,105 passed, 134 skipped
- post-follow-up contract and executable-documentation slice: 78 passed
- independent contract-file rerun: 75 passed
- explicit float16, float32, and float64 boundary oracle passed
- huge positive and negative integer labels produce targeted `ValueError`s rather than overflow leaks
- affected simulator/HSSM-support regression slice before the follow-up: 175 passed
- validator module coverage after the follow-up: 94%
- focused mypy check
- repository-wide `ruff check .` and `ruff format --check .`
- `mkdocs build --strict`
- clean Python 3.12 source-distribution and wheel build before the follow-up; verified the wheel contains the new module and no stale Python 3.14 extensions
- `git diff --check`

No dependency declarations or lockfile contents change in this PR.

## Deferred

- 6A2: an explicit legacy `rts`/`choices` adapter
- 6A3: opt-in producer/registry metadata and migration of selected simulators
- downstream HSSM, RLSSM, LANfactory, GUI, and other consumer adoption


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for structured observation results, including schemas, metadata, dimensions, omission masks, and value domains.
  * Exported the observation schema version and validation utility for public use.

* **Documentation**
  * Added comprehensive structured-observation guides, API reference material, navigation links, and executable examples.

* **Tests**
  * Added coverage for valid and invalid observation results, omission handling, metadata preservation, schema rules, and documentation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->