### PR TITLE
Add the `dev_rlddm` simulator (generated from fontanesi-2019-rlddm)

### DIFF
--- a/ssms/config/_modelconfig/__init__.py
+++ b/ssms/config/_modelconfig/__init__.py
@@ -1,4 +1,5 @@
 """Model configuration module for SSM simulators."""
+from .dev_rlddm import get_dev_rlddm_config
 
 from .ddm import (
     get_ddm_config,
@@ -191,6 +192,7 @@ def get_model_config():
     """
     # TODO: Refactor to load these lazily
     configs = {
+        "dev_rlddm": get_dev_rlddm_config(),
         "ddm": get_ddm_config(),
         "ddm_st": get_ddm_st_config(),
         "ddm_truncnormt": get_ddm_truncnormt_config(),
@@ -311,6 +313,7 @@ def get_model_config():
 
 
 __all__ = [
+    "get_dev_rlddm_config",
     "get_model_config",
     "get_ddm_config",
     "get_angle_config",

--- a/ssms/config/_modelconfig/dev_rlddm.py
+++ b/ssms/config/_modelconfig/dev_rlddm.py
@@ -1,0 +1,196 @@
+# Contributed from a paper by HSSMCortex.
+#
+#   Paper   : fontanesi-2019-rlddm
+#   Spec    : papers/ssm-theory/fontanesi-2019-rlddm.spec.md
+#   Report  : papers/ssm-theory/fontanesi-2019-rlddm.report.json
+#   ssms    : 0.13.2
+#   Verdict : draft (amber)
+#
+# Machine-generated from the paper's ModelSpec and checked against the verification
+# ladder described in the pull request body. This file is the artifact that report was
+# produced from; it is transferred rather than rewritten, so the two cannot drift apart.
+
+"""GENERATED from papers/ssm-theory/fontanesi-2019-rlddm.md — do not edit by hand.
+
+Emitted by ``scripts/generate_model.py`` from ``dev_rlddm``'s ModelSpec. Every
+component below either resolves in an ``ssms`` registry or is generated from the spec's own
+expression, and the report says which.
+
+Regenerate rather than patch: an edit here is invisible to the spec that is supposed to describe it.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import numpy as np
+
+#: ASSUMED -- the paper states none of these, and each was filled from the source
+#: named beside it. A reviewer is being asked to accept them; the verdict is capped
+#: at a draft while any remain.
+#:   model_name = 'dev_rlddm'  <- the spec's own `family`
+MODEL_NAME = "dev_rlddm"
+DONOR = "conflict_ds"
+#: Fields the paper left silent, filled from the source named beside each. Empty for a spec that
+#: stated everything codegen reads.
+ASSUMPTIONS: list[dict[str, Any]] = [{"field": "model_name", "value": "dev_rlddm", "source": "the spec's own `family`", "why": "`ssms` carries 113 entries and none of them cites a paper; the convention is compositional. `rlddm` is the paper's own name for the model class, taken from `family`, and `dev_` is where a machine-proposed model belongs until a maintainer promotes it -- the namespace `dev_rlwm_lba_pw_v1` already occupies", "kind": "notational", "falsifier": "a maintainer preferring a different token, or an existing entry that already models this -- in which case this paper contributes a citation and a benchmark to it rather than `dev_rlddm`", "confidence": "medium"}]
+BASE_THETA: dict[str, float] = {"v": 0.0, "a": 0.0, "z": 0.5, "t": 0.75, "etaPos": 0.155, "etaNeg": 0.155, "vMod": 1.05, "vMax": 3.75, "aFix": 1.05, "aMod": -0.02, "qCor": 41.25, "qInc": 41.25, "qPres": 41.25}
+REDUCTION_THETA: dict[str, float] = {"etaPos": 0.0, "etaNeg": 0.0, "vMod": 0.0, "vMax": 0.0, "aFix": 0.0, "aMod": 0.0, "qCor": 0.0, "qInc": 0.0, "qPres": 0.0}
+GENERATED_COMPONENTS = ["boundary", "drift"]
+
+#: The spec's own parameter names, mapped onto the ones theta actually carries. Emitted because
+#: the spec's `relations.reduces_to.parameter_map`, its benchmarks and its `design.schedule` binds
+#: are all written in the PAPER's notation while this config is written in the registry's, and the
+#: rungs have to evaluate one against the other.
+#:
+#: Two renamings are merged here and both must be, because a consumer cannot tell them apart and
+#: should not have to: the conventions the spec states about itself (`t_er` is the non-decision
+#: time, so it is `t`), and the spelling `ssms` requires of anything it registers (`eta_pos`
+#: carries an underscore, which its import-time validator rejects, so it is `etaPos`).
+# Every map from a name the SPEC uses to the name this module emits, in one dict. Three produce
+# one: the convention aliases, the DYNAMICS renaming when the drift was inherited rather than
+# generated, and the upstream renaming `ssms` imposes.
+#
+# The dynamics renaming was missing, and the omission was invisible until a paper needed it.
+# `busemeyer-1993-dft` writes its drift `delta - sPlusC * P`, which `ornstein` already computes as
+# `v - g * x`, so the module is built on `v` and `g` while the spec's reduction still names
+# `delta`. Rung 2 evaluated the reduction`s parameter_map and came back `name 'delta' is not
+# defined`, so the one rung that could have judged this model never ran -- reported as though the
+# reduction were untestable rather than as a renaming this file failed to publish.
+CONVENTION_ALIASES: dict[str, str] = {"t_er": "t", "eta_pos": "etaPos", "eta_neg": "etaNeg", "v_mod": "vMod", "v_max": "vMax", "a_fix": "aFix", "a_mod": "aMod", "q_cor": "qCor", "q_inc": "qInc", "q_pres": "qPres"}
+
+#: Values derived from the spec rather than fitted -- a starting point stated as a fraction of the
+#: boundary is a constant, not a parameter, and must not be given a range to be searched over.
+DERIVED_CONSTANTS: dict[str, float] = {"z": 0.5}
+
+def _donor_config() -> dict[str, Any]:
+    """The donor's config, resolved without importing a package that is still initializing.
+
+    `ssms` calls every registered factory from `_validate_configs()` at the END of
+    `ssms/config/_modelconfig/__init__.py`, which itself runs while `ssms/config/__init__.py` is
+    only part way through its own imports. So `from ssms.config import model_config` here raises
+    `cannot import name 'model_config' from partially initialized module` -- and the whole package
+    stops importing, for every user of it, on the strength of one contributed model.
+
+    By the time the factory is called, every donor factory is already bound in the `_modelconfig`
+    namespace, so it is taken from there. The package-level lookup remains as the path for any
+    caller reaching this module after `ssms` has finished importing.
+    """
+    import importlib
+
+    package = importlib.import_module("ssms.config._modelconfig")
+    factory = getattr(package, f"get_{{DONOR}}_config", None)
+    if factory is not None:
+        return factory()
+    from ssms.config import model_config
+
+    return model_config[DONOR]
+
+
+BOUNDARY_NAME = "dev_rlddm_boundary"
+
+#: Parameters the boundary function expects. ``a`` must be here when the expression uses it: ssms
+#: filters theta down to these names, so omitting one does not raise -- the function silently falls
+#: back to its own default and simulates a bound unrelated to the one being passed.
+BOUNDARY_PARAMS = ["aFix", "aMod", "qPres"]
+
+
+def dev_rlddm_boundary(t: float | np.ndarray = 0.0, aFix: float = 1.0, aMod: float = 1.0, qPres: float = 1.0) -> float | np.ndarray:
+    """Generated from the spec's boundary expression.
+
+    ``b(t) = (exp(aFix + aMod * qPres)) * 0.5``
+
+    This is the one place free-form code is written rather than a registry component named, and it
+    is the capability a genuinely novel model is most likely to need.
+    """
+    t = np.asarray(t)
+    return np.exp(aFix + aMod * qPres) * 0.5
+
+
+def register_boundary_once() -> None:
+    # From the SUBMODULE, not the package. This runs while `ssms.config` is still executing its own
+    # `__init__` -- `_validate_configs()` calls every registered factory at import -- so importing
+    # the package here raises `cannot import name ... from partially initialized module`.
+    # `boundary_registry` is imported before `_modelconfig`, so reaching it directly is safe.
+    from ssms.config.boundary_registry import get_boundary_registry, register_boundary
+
+    if get_boundary_registry().is_registered(BOUNDARY_NAME):
+        return
+    register_boundary(name=BOUNDARY_NAME, function=dev_rlddm_boundary, params=BOUNDARY_PARAMS)
+
+
+DRIFT_NAME = "dev_rlddm_drift"
+
+#: Parameters the drift function expects. The same trap as BOUNDARY_PARAMS, and sharper: ssms
+#: resolves the drift by NAME out of the registry and filters theta down to the names recorded
+#: here, so a parameter omitted from this list does not raise -- the function falls back to its own
+#: default and integrates a rate unrelated to the one being fitted.
+DRIFT_PARAMS = ["vMod", "vMax", "qCor", "qInc"]
+
+
+def dev_rlddm_drift(t: float | np.ndarray = 0.0, vMod: float = 1.0, vMax: float = 1.0, qCor: float = 1.0, qInc: float = 1.0) -> np.ndarray:
+    """Generated from the spec's drift expression.
+
+    ``v(t) = 2 * vMax / (1 + exp(-(vMod * (qCor - qInc)))) - vMax``
+
+    Returns an ARRAY shaped like `t`, always, which is the contract every drift in the registry
+    keeps: `constant`, `gamma_drift` and `attend_drift_simple` all annotate `np.ndarray` and all
+    return one shaped like the time grid they are handed.
+
+    Measured, so the reason is not overstated: `ssms` 0.13.2 also simulates a drift that returns a
+    bare scalar. Matching the registry is a contract decision, not a workaround for a failure --
+    and `np.zeros_like(t) +` costs nothing for an expression that already depends on `t`.
+    """
+    t = np.asarray(t, dtype=float)
+    return np.zeros_like(t) + (2 * vMax / (1 + np.exp(-(vMod * (qCor - qInc)))) - vMax)
+
+
+def register_drift_once() -> None:
+    # From the SUBMODULE; see `register_boundary_once`.
+    from ssms.config.drift_registry import get_drift_registry, register_drift
+
+    if get_drift_registry().is_registered(DRIFT_NAME):
+        return
+    register_drift(name=DRIFT_NAME, function=dev_rlddm_drift, params=DRIFT_PARAMS)
+
+
+def get_dev_rlddm_config() -> dict[str, Any]:
+    """Return the generated ``model_config`` entry.
+
+    The donor supplies the simulator and the parameter transforms — 80 of the zoo's 113 models
+    carry a non-empty transform, so emitting one is the norm rather than an edge case — and this
+    config swaps in the components the spec names.
+    """
+    from ssms.config.boundary_registry import get_boundary_registry
+
+    donor = _donor_config()
+    cfg = copy.deepcopy({
+        k: v for k, v in donor.items()
+        if k not in ("boundary", "simulator", "parameter_transforms", "param_bounds_dict")
+    })
+
+    cfg["name"] = MODEL_NAME
+    cfg["params"] = ["v", "a", "z", "t", "etaPos", "etaNeg", "vMod", "vMax", "aFix", "aMod", "qCor", "qInc", "qPres"]
+    cfg["param_bounds"] = [[0.0, 0.0, 0.5, 0.4, 0.01, 0.01, 0.1, 1.5, 0.3, -0.05, 27.5, 27.5, 27.5], [0.0, 0.0, 0.5, 1.1, 0.3, 0.3, 2.0, 6.0, 1.8, 0.01, 55.0, 55.0, 55.0]]
+    cfg["n_params"] = 13
+    cfg["default_params"] = [0.0, 0.0, 0.5, 0.75, 0.155, 0.155, 1.05, 3.75, 1.05, -0.02, 41.25, 41.25, 41.25]
+    cfg["nchoices"] = 2
+    cfg["choices"] = [-1, 1]
+    cfg["n_particles"] = donor.get("n_particles", 1)
+    # Carried so an oracle can tell a RENAMED parameter from a dead one: the spec still declares
+    # `t_er` while the model is fitted over `t`, and perturbing the spec's name moves nothing.
+    cfg["convention_aliases"] = CONVENTION_ALIASES
+    cfg["derived_constants"] = DERIVED_CONSTANTS
+
+    register_boundary_once()
+    cfg["boundary_name"] = BOUNDARY_NAME
+    cfg["boundary"] = dev_rlddm_boundary
+    cfg["boundary_params"] = BOUNDARY_PARAMS
+    register_drift_once()
+    cfg["drift_name"] = DRIFT_NAME
+    cfg["drift_fun"] = dev_rlddm_drift
+
+    cfg["simulator"] = donor["simulator"]
+    cfg["parameter_transforms"] = copy.deepcopy(donor["parameter_transforms"])
+    return cfg

--- a/tests/test_dev_rlddm.py
+++ b/tests/test_dev_rlddm.py
@@ -1,0 +1,66 @@
+"""Tests for the `dev_rlddm` model configuration.
+
+Contributed from a paper via HSSMCortex. The generative claims below are the ones its verification
+report checked; see the pull request body for the report and the rungs that ran.
+"""
+
+import numpy as np
+import pytest
+
+from ssms.basic_simulators.simulator import simulator
+from ssms.config import model_config
+
+
+N_SAMPLES = 20_000
+
+
+def _theta(name):
+    cfg = model_config[name]
+    return dict(zip(cfg["params"], cfg["default_params"]))
+
+
+def test_dev_rlddm_is_registered():
+    """The config resolves through the registry the package exposes."""
+    assert "dev_rlddm" in model_config
+    cfg = model_config["dev_rlddm"]
+    assert len(cfg["params"]) == cfg["n_params"] == len(cfg["default_params"])
+    assert len(cfg["param_bounds"][0]) == len(cfg["param_bounds"][1]) == cfg["n_params"]
+
+
+def test_dev_rlddm_simulates():
+    """It runs, and produces response times no smaller than its own non-decision time."""
+    cfg = model_config["dev_rlddm"]
+    theta = _theta("dev_rlddm")
+    out = simulator(model="dev_rlddm", theta=theta, n_samples=N_SAMPLES)
+    rts = np.asarray(out["rts"]).ravel()
+    assert np.isfinite(rts).all()
+    assert set(np.unique(np.asarray(out["choices"]).ravel())) <= set(cfg["choices"])
+    if "t" in theta:
+        assert rts.min() >= theta["t"] - 1e-9
+
+
+def test_dev_rlddm_reduces_to_ddm():
+    """With a_mod = 0.0 the new mechanism is off and this must be `ddm`.
+
+    The paper's own claim, and the one the contributing pipeline checked at rung 2. Compared as
+    response-time distributions per choice rather than sample by sample, because the two models are
+    only required to agree in law.
+    """
+    theta = _theta("dev_rlddm")
+    theta['a_mod'] = 0.0
+    ours = simulator(model="dev_rlddm", theta=theta, n_samples=N_SAMPLES, random_state=7)
+    theirs = simulator(model="ddm", theta=_theta("ddm"), n_samples=N_SAMPLES,
+                       random_state=7)
+
+    for choice in model_config["ddm"]["choices"]:
+        a = np.asarray(ours["rts"]).ravel()[np.asarray(ours["choices"]).ravel() == choice]
+        b = np.asarray(theirs["rts"]).ravel()[np.asarray(theirs["choices"]).ravel() == choice]
+        if min(len(a), len(b)) < 500:
+            continue
+        grid = np.quantile(np.concatenate([a, b]), np.linspace(0.01, 0.99, 99))
+        gap = np.abs(
+            np.searchsorted(np.sort(a), grid) / len(a)
+            - np.searchsorted(np.sort(b), grid) / len(b)
+        ).max()
+        band = 3.0 * np.sqrt(2.0 / min(len(a), len(b)))
+        assert gap <= band, f"choice {choice}: D = {gap:.4f} against a band of {band:.4f}"


### PR DESCRIPTION
Rungs 2 (reduction), 3 (benchmark) ran. Not run: rung 1 (reference) — the model has no ssms entry, which is the normal case for a new model: rung 1 is unavailable BY DEFINITION for anything genuinely novel, since the registry cannot already carry it; rung 4 (recovery) — timed one fit cycle: 0.114 min at 1000 trials.

**Opened as a draft.** The verification report reached only the rungs listed below. `verified` is reserved for a spec reaching rung 1 or rung 3 — see the contribution contract §2 for why this is the expected shape of a novel-model contribution rather than a failure.

**This opens as a draft because every failure is explained, not because none failed.**

*Accounted for by a diagnosis*: `benchmark:results_behavioral_learning_effect:accuracy_first_20_trials`, `benchmark:results_behavioral_learning_effect:accuracy_last_20_trials`, `benchmark:results_behavioral_difficulty_effect:accuracy_easy_AC_BD`, `benchmark:results_behavioral_difficulty_effect:accuracy_difficult_AB_CD`, `benchmark:results_behavioral_magnitude_effect:accuracy_high_value_pairs`, `benchmark:results_behavioral_magnitude_effect:accuracy_low_value_pairs` — no prediction covered these; the harness identified their cause afterwards, from the sign pattern across statistic classes. See **Review this first** above. The reviewer, not the pipeline, decides whether the account holds.



## Review this first

> **The specification behind this contribution has not been read by a person.** Its `provenance.review_status` is `proposal`: a model extracted this paper's model from the paper, and everything below follows from that reading. Treat the whole contribution as a proposal about what the paper says, not as a transcription of it.

This contribution was generated by reading a paper, and a paper does not state every quantity a simulator needs. Below is everything the pipeline decided that the paper did not, and everything it could not verify but can explain. Each row says what would show it wrong.

### Assumed — the paper is silent, the pipeline filled it in

| Field | Value | Kind | Taken from | Wrong if |
| --- | --- | --- | --- | --- |
| `model_name` | `dev_rlddm` | notational | the spec's own `family` | a maintainer preferring a different token, or an existing entry that already models this -- in which case this paper contributes a citation and a benchmark to it rather than `dev_rlddm` |

### Diagnosed — checks that failed, and why

**These are still failures.** A diagnosis is the pipeline's account of the cause, measured rather than asserted; it does not turn a `fail` into a `pass`, and no parameter was adjusted to close any gap. It is what to look at first.

**drift too large** — high confidence, covering 12 check(s).

- *measured*: 12 benchmark values across 2 statistic class(es) miss in one direction: central_rt below published in 6 of 6, proportion above published in 6 of 6. Of the 6 single causes this family admits, that pattern is produced by exactly one
- *look at*: the scale of the drift's input. A drift built from a quantity the paper reports on one scale (a learning signal, a value difference) and consumed on another is off by a factor in exactly this direction. The reading this runs through is one the extractor was not sure of -- `process.dynamics.drift.expression`, `process.dynamics.drift.time_dependence`, `process.dynamics.noise.scale`, `conventions.paper.noise_scale` graded low/medium in `provenance.field_confidence`
- *refuted by*: a condition where the published accuracy is HIGHER than the simulated one. One such condition refutes a uniform drift excess


| Provenance | |
| --- | --- |
| Spec | `papers/ssm-theory/fontanesi-2019-rlddm.spec.md` |
| Report | `papers/ssm-theory/fontanesi-2019-rlddm.report.json` |
| `ssms` version | `0.13.2` |
| Verdict | `draft (amber)` (gate arm: amber) |
| Consultation | `pending` |

This change was opened by a machine and is **awaiting human approval**. It is a draft: nothing here has been approved by a person, and the checks above are the machine's own account of its work. Merging is the approval.

**Verification**

| Check | Result | Predicted | Accounted |
| --- | --- | --- | --- |
| `conventions` | pass | — | — |
| `property:candidate__dev_rlddm` | pass | — | — |
| `structural:candidate__dev_rlddm` | pass | — | — |
| `analytic` | not_run | — | — |
| `reference` | not_run | — | — |
| `reduction:ddm` | pass | — | — |
| `reduction:ddm` | pass | — | — |
| `benchmark:results_behavioral_learning_effect:accuracy_first_20_trials` | fail | — | yes |
| `benchmark:results_behavioral_learning_effect:accuracy_last_20_trials` | fail | — | yes |
| `benchmark:results_behavioral_learning_effect:mean_rt_first_20_trials_s` | advisory | — | — |
| `benchmark:results_behavioral_learning_effect:mean_rt_last_20_trials_s` | advisory | — | — |
| `benchmark:results_behavioral_difficulty_effect:accuracy_easy_AC_BD` | fail | — | yes |
| `benchmark:results_behavioral_difficulty_effect:accuracy_difficult_AB_CD` | fail | — | yes |
| `benchmark:results_behavioral_difficulty_effect_rt:mean_rt_easy_s` | advisory | — | — |
| `benchmark:results_behavioral_difficulty_effect_rt:mean_rt_difficult_s` | advisory | — | — |
| `benchmark:results_behavioral_magnitude_effect:accuracy_high_value_pairs` | fail | — | yes |
| `benchmark:results_behavioral_magnitude_effect:accuracy_low_value_pairs` | fail | — | yes |
| `benchmark:results_behavioral_magnitude_effect:mean_rt_high_value_pairs_s` | advisory | — | — |
| `benchmark:results_behavioral_magnitude_effect:mean_rt_low_value_pairs_s` | advisory | — | — |
| `recovery` | not_run | — | — |