### PR TITLE
docs: adopt the shared documentation platform

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/docs.yml"
+      - ".github/workflows/reusable-docs.yml"
       - ".lychee.toml"
       - "docs/**"
       - "mkdocs.yml"
@@ -16,6 +17,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/docs.yml"
+      - ".github/workflows/reusable-docs.yml"
       - ".lychee.toml"
       - "docs/**"
       - "mkdocs.yml"
@@ -36,6 +38,6 @@ permissions:
 
 jobs:
   docs:
-    uses: lnccbrown/HSSMSpine/.github/workflows/reusable-docs.yml@1c8129bb4c0997ada5b4d062e05357757c86eb90
+    uses: ./.github/workflows/reusable-docs.yml
     with:
       system-profile: gsl

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,115 +1,41 @@
-name: docs
+name: Docs
 
 on:
   pull_request:
     paths:
+      - ".github/workflows/docs.yml"
+      - ".lychee.toml"
       - "docs/**"
       - "mkdocs.yml"
       - "pyproject.toml"
+      - "scripts/docs.sh"
+      - "src/cssm/**"
       - "ssms/**"
-      - ".github/workflows/docs.yml"
+      - "uv.lock"
   push:
-    branches:
-      - main
+    branches: [main]
     paths:
+      - ".github/workflows/docs.yml"
+      - ".lychee.toml"
       - "docs/**"
       - "mkdocs.yml"
       - "pyproject.toml"
+      - "scripts/docs.sh"
+      - "src/cssm/**"
       - "ssms/**"
-      - ".github/workflows/docs.yml"
-  release:
-    types: [published]
-  workflow_dispatch:
+      - "uv.lock"
   schedule:
-    # Weekly link check, Mondays 06:23 UTC (off-peak)
+    # Retain the established Monday 06:23 UTC rendered-link check.
     - cron: "23 6 * * 1"
+  workflow_dispatch:
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 jobs:
-  build:
-    name: Build docs (strict)
-    if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Update apt cache
-        run: sudo apt-get update
-      - name: Install GSL
-        run: sudo apt-get install -y libgsl-dev
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: "latest"
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
-
-      - name: Install package with docs dependencies
-        run: uv sync --no-dev --group docs
-
-      - name: Build docs (strict)
-        run: uv run mkdocs build --strict
-
-  deploy:
-    name: Deploy docs to GitHub Pages
-    needs: build
-    if: >-
-      github.event_name == 'release' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Update apt cache
-        run: sudo apt-get update
-      - name: Install GSL
-        run: sudo apt-get install -y libgsl-dev
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: "latest"
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
-
-      - name: Install package with docs dependencies
-        run: uv sync --no-dev --group docs
-
-      - name: Configure git for deploy
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Deploy to gh-pages
-        run: uv run mkdocs gh-deploy --force
-
-  linkcheck:
-    name: Check external links
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Run lychee link checker
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: --no-progress './docs/**/*.md' 'README.md'
-          fail: true
+  docs:
+    uses: lnccbrown/HSSMSpine/.github/workflows/reusable-docs.yml@1c8129bb4c0997ada5b4d062e05357757c86eb90
+    with:
+      system-profile: gsl

--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -1,9 +1,9 @@
 name: Drift
 
 # Scheduled drift detection: re-run the full test workflow (unit matrix,
-# GSL/OpenMP multithreading, notebooks) against a fresh dependency resolve of
-# an unchanged main. No lockfile is committed, so a red run here means an
-# upstream or toolchain release broke us — before any PR trips over it.
+# GSL/OpenMP multithreading, notebooks) against the committed lockfile on an
+# unchanged main. A red run here signals runner, action, or system-toolchain
+# drift — before any PR trips over it.
 # Failures file ONE deduped `drift`-labeled issue; green runs close it.
 on:
   schedule:
@@ -20,8 +20,8 @@ permissions:
 
 jobs:
   tests:
-    # Only `report` needs issue-write; the token that runs freshly-resolved
-    # third-party test code should not carry it.
+    # Only `report` needs issue-write; the token that runs third-party code
+    # installed from the committed lockfile should not carry it.
     permissions:
       contents: read
     uses: ./.github/workflows/run_tests.yml
@@ -91,7 +91,7 @@ jobs:
               "Scheduled drift run failed in:${FAILED_JOBS}" \
               "Run: $RUN_URL" \
               "" \
-              "This re-runs the existing test workflow against a fresh dependency resolve of an unchanged main — a failure usually means an upstream or toolchain release, not a code change." \
+              "This re-runs the existing test workflow against the committed lockfile on an unchanged main — a failure usually means runner, action, or system-toolchain drift, not a code change." \
               "Triage via the spine's audit-drift skill.")
             gh issue create --repo "$GITHUB_REPOSITORY" --label drift \
               --title "$TITLE" --body "$BODY"

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -1,0 +1,142 @@
+name: Reusable native docs
+
+on:
+  workflow_call:
+    inputs:
+      system-profile:
+        description: Linux system dependencies (none, blas-lapack, or gsl)
+        required: false
+        default: none
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Validate system profile
+        shell: bash
+        env:
+          SYSTEM_PROFILE: ${{ inputs['system-profile'] }}
+        run: |
+          case "$SYSTEM_PROFILE" in
+            none|blas-lapack|gsl) ;;
+            *)
+              echo "Unsupported system-profile: $SYSTEM_PROFILE" >&2
+              exit 2
+              ;;
+          esac
+
+      - name: Check out caller repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.2"
+          enable-cache: true
+
+      - name: Install system dependencies
+        shell: bash
+        env:
+          SYSTEM_PROFILE: ${{ inputs['system-profile'] }}
+        run: |
+          case "$SYSTEM_PROFILE" in
+            none)
+              exit 0
+              ;;
+            blas-lapack)
+              packages=(libblas-dev liblapack-dev)
+              ;;
+            gsl)
+              packages=(libgsl-dev)
+              ;;
+          esac
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends "${packages[@]}"
+
+      - name: Build documentation
+        run: ./scripts/docs.sh build
+
+      - name: Verify Pages output
+        run: test -f site/index.html
+
+      # GitHub project sites are served below /<repository>/. Mount site/ at
+      # that path so Lychee can resolve Material's root-relative URLs against
+      # the current artifact instead of requiring an already-deployed site.
+      - name: Mount rendered site at Pages path
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          if [[ ! "$GITHUB_REPOSITORY" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+            echo "Unsupported repository name: $GITHUB_REPOSITORY" >&2
+            exit 2
+          fi
+          docs_project="${GITHUB_REPOSITORY#*/}"
+          if [[ "$docs_project" == "." || "$docs_project" == ".." ]]; then
+            echo "Unsupported Pages project path: $docs_project" >&2
+            exit 2
+          fi
+          docs_link_root="$RUNNER_TEMP/docs-link-root"
+          mkdir -p -- "$docs_link_root"
+          ln -s -- "$GITHUB_WORKSPACE/site" "$docs_link_root/$docs_project"
+
+      # Link-check rendered HTML so generated reference and notebook links are
+      # covered. Schedules and manual dispatches remain in the caller workflow.
+      - name: Check rendered links
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: >-
+            --config '${{ github.workspace }}/.lychee.toml'
+            --root-dir '${{ runner.temp }}/docs-link-root'
+            --no-progress
+            '${{ github.workspace }}/site/**/*.html'
+          fail: true
+          failIfEmpty: true
+
+      - name: Upload Pages artifact
+        if: >-
+          github.ref == 'refs/heads/main' &&
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: site
+
+  deploy:
+    name: Deploy documentation
+    needs: build
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: docs-pages-${{ github.repository }}
+      cancel-in-progress: false
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Deploy Pages artifact
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,4 @@
+cache = true
+max_cache_age = "1d"
+max_retries = 3
+timeout = 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,9 @@ uv run ruff check . && uv run ruff format --check .
 # Rebuild Cython extensions after C/pyx changes
 uv run python setup.py build_ext --inplace
 
-# Build docs
-uv run --extra docs mkdocs build
-uv run --extra docs mkdocs serve
+# Build docs strictly or preview them locally
+./scripts/docs.sh build
+./scripts/docs.sh serve
 
 # CLI: generate training data from YAML config
 uv run generate --config-path <path> --output <dir>

--- a/README.md
+++ b/README.md
@@ -19,263 +19,51 @@
 
 `ssm-simulators` provides fast C/Cython simulators for sequential sampling
 models used in cognitive science, neuroscience, and amortized Bayesian
-inference, spanning classic DDM variants, multi-choice models, attention
-models, and reinforcement-learning SSMs.
+inference. It is the simulator and training-data layer of the
+[HSSM ecosystem](https://lnccbrown.github.io/HSSM/ecosystem/).
 
----
+## Install
 
-## At a Glance
-
-| Need | Use ssms for |
-| --- | --- |
-| Simulate behavior | Generate response-time and choice data from a broad SSM library. |
-| Train likelihood networks | Produce LAN/LANfactory-style training data with configurable simulators and KDE estimators. |
-| Prototype models | Combine registered model configs, custom drift/boundary functions, parameter transforms, and Cython extensions. |
-| Work with RLSSMs | Simulate trial-wise learning models, response-only choice models, and posterior predictive functions for RL workflows. |
-
-Core links:
-
-- Documentation: <https://lnccbrown.github.io/ssm-simulators/>
-- API reference: <https://lnccbrown.github.io/ssm-simulators/api/ssms/>
-- RLSSM API: <https://lnccbrown.github.io/ssm-simulators/api/rlssm/>
-- Issues and feature requests: <https://github.com/lnccbrown/ssm-simulators/issues>
-
----
-
-## Model Coverage
-
-| Family | Examples |
-| --- | --- |
-| Diffusion models | DDM, full DDM, deadline variants, angle and Weibull boundaries, Levy, Ornstein-Uhlenbeck, gamma-drift, conflict, tradeoff, and shrink-spotlight variants. |
-| Multi-choice accumulators | Race, racing diffusion, LBA, LBA4, LCA, and Poisson race models. |
-| Attention models | aDDM with observed or self-sampled fixations, continuation strategies, and optional trajectory metadata. |
-| Reinforcement-learning SSMs | Rescorla-Wagner learning rules, RT + choice RLSSMs, inverse-temperature softmax choice-only models, and response-only posterior predictive workflows. |
-
-RL support includes inverse-temperature softmax decision processes for two-,
-three-, and four-choice settings, plus RT + choice race models. Built-in RL
-presets include Rescorla-Wagner DDM/angle/Weibull models, dual-alpha variants,
-choice-only inverse-temperature softmax bandits such as
-`2AB_RW_InvTempSoftmax`, `3AB_RW_InvTempSoftmax`, and
-`4AB_RW_InvTempSoftmax`, and the four-choice RT + choice race preset
-`4AB_RW_RaceNoBiasAngle`.
-
----
-
-## Where ssms Fits
-
-`ssm-simulators` is the simulator and data-generation layer of the HSSM
-ecosystem.
-
-| Package | Relationship |
-| --- | --- |
-| [HSSM](https://github.com/lnccbrown/HSSM) | Builds Bayesian inference workflows around simulator-defined model configurations, including ssms-defined RLSSMs. |
-| [LANfactory](https://github.com/lnccbrown/LANfactory) | Trains likelihood approximation networks from ssms-generated simulation data. |
-| [LAN_pipeline_minimal](https://github.com/lnccbrown/LAN_pipeline_minimal) | Orchestrates simulation and LAN training pipelines. |
-
-The RLSSM path is ssms-first: ssms owns the learning rule, task environment,
-response mapping, and simulator/PPC behavior; HSSM consumes the assembled model
-contract through `hssm.rl.RLSSMConfig.from_ssms_model(...)` for inference.
-
----
-
-## Installation
-
-```sh
+```bash
 pip install ssm-simulators
 ```
 
-Install the optional JAX backend for differentiable RLSSM learning processes:
+The [documentation](https://lnccbrown.github.io/ssm-simulators/) is the
+canonical source for optional backends, OpenMP/GSL prerequisites, tutorials,
+model coverage, configuration, and API contracts.
 
-```sh
-pip install "ssm-simulators[jax]"
-```
+## Start here
 
-> [!NOTE]
-> Multi-threaded simulation with `n_threads > 1` requires OpenMP and GSL.
-> Install system dependencies first:
->
-> ```bash
-> # macOS
-> brew install libomp gsl
->
-> # Ubuntu/Debian
-> sudo apt-get install build-essential libgsl-dev
-> ```
->
-> Then reinstall with `pip install --force-reinstall ssm-simulators`.
-> Without these dependencies, the package still works in single-threaded mode.
->
-> Building from source or developing this package requires a C compiler. Most
-> users installing from PyPI wheels do not need to install GCC manually.
-
----
-
-## Quick Starts
-
-### Classic SSM Simulation
-
-The `Simulator` class is the recommended user-facing API for direct simulation:
-
-```python
-from ssms.basic_simulators import Simulator
-
-sim = Simulator("ddm")
-out = sim.simulate(
-    theta={"v": 1.0, "a": 1.5, "z": 0.5, "t": 0.2},
-    n_samples=1000,
-)
-
-print(out["rts"].shape, out["choices"].shape)
-```
-
-### RLSSM Simulation
-
-RLSSMs combine a trial-wise learning process, a task environment, and an SSM or
-choice-only decision process:
-
-```python
-import ssms.rl as rl
-
-config = rl.preset.get("2AB_RW_InvTempSoftmax")
-sim = rl.Simulator(config)
-
-data = sim.simulate(
-    theta={"rl_alpha": 0.2, "beta": 2.0},
-    n_trials=200,
-    n_participants=20,
-    random_state=42,
-)
-
-response_only = data.drop(columns=["rt"])
-config.validate_data(response_only).raise_for_errors()
-```
-
-For choice-only models, the simulator keeps `rt=-1.0` only as a compatibility
-placeholder in generative output. HSSM inference and ssms PPC use response-only
-data.
-
----
-
-## Tutorials
-
-Start here:
-
-- [Basic tutorial](https://lnccbrown.github.io/ssm-simulators/basic_tutorial/basic_tutorial/)
-- [Package overview](https://lnccbrown.github.io/ssm-simulators/core_tutorials/tutorial_capabilities/)
-- [RLSSM tutorial](https://lnccbrown.github.io/ssm-simulators/core_tutorials/rlssm_tutorial/)
-- [RLSSM simulation and HSSM handoff](https://lnccbrown.github.io/ssm-simulators/core_tutorials/rlssm_simulation_hssm_handoff/)
-- [Choice-only RL models](https://lnccbrown.github.io/ssm-simulators/core_tutorials/choice_only_rl_models/)
-- [Contributing new models](https://lnccbrown.github.io/ssm-simulators/contributing/add_models/)
-
----
-
-## Training Data CLI
-
-The package exposes `generate` for creating training data from a YAML
-configuration file:
-
-```bash
-generate [--config-path <path/to/config.yaml>] --output <output/directory> [--log-level INFO]
-```
-
-Common options:
-
-| Option | Meaning |
-| --- | --- |
-| `--config-path` | YAML configuration path. Uses the default config if omitted. |
-| `--output` | Output directory for generated data. |
-| `--n-files` | Number of data files to generate. |
-| `--estimator-type` | Likelihood estimator override, such as `kde` or `pyddm`. |
-| `--log-level` | Logging level. |
-
-Minimal YAML example:
-
-```yaml
-MODEL: "ddm"
-GENERATOR_APPROACH: "lan"
-
-PIPELINE:
-  N_PARAMETER_SETS: 100
-  N_SUBRUNS: 20
-
-SIMULATOR:
-  N_SAMPLES: 2000
-  DELTA_T: 0.001
-
-TRAINING:
-  N_SAMPLES_PER_PARAM: 200
-
-ESTIMATOR:
-  TYPE: "kde"
-```
-
----
-
-## Parallel Execution
-
-When using `n_threads > 1`, ssms uses GSL's validated Ziggurat algorithm for
-Gaussian random number generation. The maximum supported number of threads is
-256.
-
-```python
-from ssms.basic_simulators import Simulator
-
-theta = {"v": 1.0, "a": 1.5, "z": 0.5, "t": 0.2}
-
-sim = Simulator("ddm")
-single_thread = sim.simulate(theta=theta, n_samples=10000, n_threads=1)
-multi_thread = sim.simulate(theta=theta, n_samples=10000, n_threads=8)
-```
-
-Check your installation's parallel capabilities:
-
-```python
-from cssm._openmp_status import print_status
-
-print_status()
-```
-
----
-
-## Development
-
-This project uses `uv` for dependency management:
-
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-uv sync --all-groups
-```
-
-Rebuild Cython extensions after source changes:
-
-```bash
-uv pip install --python .venv/bin/python -e . --reinstall
-```
-
-Run the main local checks:
-
-```bash
-uv run pytest tests/
-uv run ruff check .
-uv run ruff format --check .
-uv run --extra docs mkdocs build
-```
-
----
+- [Simulate and inspect your first SSM](https://lnccbrown.github.io/ssm-simulators/basic_tutorial/basic_tutorial/)
+- [Simulate your first RLSSM](https://lnccbrown.github.io/ssm-simulators/core_tutorials/rlssm_tutorial/)
+- [Create a custom model](https://lnccbrown.github.io/ssm-simulators/core_tutorials/tutorial_custom_models/)
+- [Browse the API reference](https://lnccbrown.github.io/ssm-simulators/api/basic_simulators/)
+- [Report an issue](https://github.com/lnccbrown/ssm-simulators/issues)
 
 ## Contributing
 
-Contributions are welcome, including new models, documentation improvements,
-bug fixes, and simulator validation work.
+Install the development environment, then run the package and documentation
+gates:
 
-- Add a model: <https://lnccbrown.github.io/ssm-simulators/contributing/add_models/>
-- Add a parameter adapter: <https://lnccbrown.github.io/ssm-simulators/contributing/add_parameter_adapters/>
-- Open an issue: <https://github.com/lnccbrown/ssm-simulators/issues>
-- Open a pull request: <https://github.com/lnccbrown/ssm-simulators/pulls>
+```bash
+uv sync --extra dev
+uv run pytest tests/
+uv run pytest tests/test_notebooks.py --run-notebooks --no-cov -v
+uv run ruff check .
+uv run ruff format --check .
+./scripts/docs.sh build
+```
 
----
+Preview documentation changes with `./scripts/docs.sh serve`. See the
+[contribution guide](https://lnccbrown.github.io/ssm-simulators/contributing/)
+and [new-model guide](https://lnccbrown.github.io/ssm-simulators/contributing/add_models/)
+for durable development guidance.
 
 ## Citation
 
-Please cite `ssm-simulators` with the Zenodo DOI:
-<https://doi.org/10.5281/zenodo.17156205>.
+Please cite `ssm-simulators` with its
+[Zenodo DOI](https://doi.org/10.5281/zenodo.17156205).
+
+## License
+
+`ssm-simulators` is distributed under the [MIT License](LICENSE).

--- a/docs/basic_tutorial/basic_tutorial.ipynb
+++ b/docs/basic_tutorial/basic_tutorial.ipynb
@@ -399,7 +399,7 @@
     "sample counts for real training data.\n",
     "\n",
     "For the full configuration and production-oriented workflow, see the\n",
-    "[training data generator tutorial](../core_tutorials/tutorial_data_generators.ipynb)."
+    "[training data generator tutorial](../../core_tutorials/tutorial_data_generators/)."
    ]
   },
   {
@@ -462,12 +462,12 @@
    "source": [
     "## Next Steps\n",
     "\n",
-    "- Browse the [simulator API](../api/basic_simulators.md) for available\n",
+    "- Browse the [simulator API](../../api/basic_simulators/) for available\n",
     "  models and simulator arguments.\n",
-    "- Inspect the [configuration API](../api/config.md) for model and\n",
+    "- Inspect the [configuration API](../../api/config/) for model and\n",
     "  generator configuration helpers.\n",
-    "- Learn how to add a [custom model](../core_tutorials/tutorial_custom_models.ipynb).\n",
-    "- Use the [training data generator tutorial](../core_tutorials/tutorial_data_generators.ipynb)\n",
+    "- Learn how to add a [custom model](../../core_tutorials/tutorial_custom_models/).\n",
+    "- Use the [training data generator tutorial](../../core_tutorials/tutorial_data_generators/)\n",
     "  for larger datasets and persistence options."
    ]
   }

--- a/docs/core_tutorials/rlssm_advanced_tutorial.ipynb
+++ b/docs/core_tutorials/rlssm_advanced_tutorial.ipynb
@@ -8,7 +8,7 @@
     "# Build custom RLSSM components\n",
     "\n",
     "This is the **advanced** companion to the\n",
-    "[RLSSM beginner tutorial](rlssm_tutorial.ipynb). The beginner tutorial showed the\n",
+    "[RLSSM beginner tutorial](../rlssm_tutorial/). The beginner tutorial showed the\n",
     "standard path: choose a preset, simulate data, plot the basic learning pattern, validate\n",
     "the data, and inspect the HSSM handoff. Here we slow down and open the machinery.\n",
     "\n",
@@ -2833,8 +2833,8 @@
     "   inference.\n",
     "5. Run generative and PPC simulations side by side after changing only one parameter.\n",
     "\n",
-    "For the foundations, revisit the [beginner tutorial](rlssm_tutorial.ipynb). For method\n",
-    "and class details, see the [`ssms.rl` API page](../api/rlssm.md).\n"
+    "For the foundations, revisit the [beginner tutorial](../rlssm_tutorial/). For method\n",
+    "and class details, see the [`ssms.rl` API page](../../api/rlssm/).\n"
    ]
   }
  ],

--- a/docs/core_tutorials/rlssm_tutorial.ipynb
+++ b/docs/core_tutorials/rlssm_tutorial.ipynb
@@ -29,7 +29,7 @@
     "> common path. Topics such as custom components, response/choice mapping, context-aware\n",
     "> learning, posterior predictive (PPC) simulation, assembled models, backend/gradient\n",
     "> control, and multi-parameter handshakes are covered in the\n",
-    "> [advanced tutorial](rlssm_advanced_tutorial.ipynb).\n"
+    "> [advanced tutorial](../rlssm_advanced_tutorial/).\n"
    ]
   },
   {
@@ -88,7 +88,7 @@
     "generates observed choice/RT data; feedback then updates Q-values for the next trial.\n",
     "\n",
     "<figure style=\"text-align: center;\">\n",
-    "    <img src=\"assets/rlssm.jpg\" width=\"50%\" alt=\"Graphical model of an RLSSM.\">\n",
+    "    <img src=\"../assets/rlssm.jpg\" width=\"50%\" alt=\"Graphical model of an RLSSM.\">\n",
     "    <figcaption>Graphical model of an RLSSM.</figcaption>\n",
     "</figure>\n",
     "\n",
@@ -1138,7 +1138,7 @@
     "parameter declared by the simulator model. A higher-level constructor —\n",
     "`hssm.RLSSM(data, model=\"2AB_RW_Angle\")` — is planned but not yet available, so for now\n",
     "use `RLSSMConfig.from_ssms_model(...)`. For the full end-to-end inference and\n",
-    "parameter-recovery workflow, see the [`ssms.rl` API reference](../api/rlssm.md).\n"
+    "parameter-recovery workflow, see the [`ssms.rl` API reference](../../api/rlssm/).\n"
    ]
   },
   {
@@ -1175,7 +1175,7 @@
     "- Use `config.validate_data(...)` on a deliberately edited dataset to see the repair\n",
     "  hints.\n",
     "\n",
-    "**Continue with the [advanced tutorial](rlssm_advanced_tutorial.ipynb)**, which covers:\n",
+    "**Continue with the [advanced tutorial](../rlssm_advanced_tutorial/)**, which covers:\n",
     "\n",
     "- response labels vs. zero-based learning choices, and explicit `response_to_choice`;\n",
     "- alternative components: dual-learning-rate Rescorla-Wagner, Gaussian-reward bandits,\n",

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,9 +1,7 @@
-{#- HSSM ecosystem shared announcement banner.
+{#- HSSM ecosystem shared Material override.
     VENDORED COPY — source of truth: https://github.com/lnccbrown/HSSMSpine
     (docs-brand/main.html). Edit there and re-sync; local edits will be
-    flagged as drift. Repo-agnostic: the release link derives from
-    config.repo_url; questions route to the ecosystem's shared forum
-    (HSSM Discussions) by design. -#}
+    flagged as drift. -#}
 {% extends "base.html" %}
 {% block announce %}
 <span class="show-on-small right-margin">
@@ -12,11 +10,13 @@
     </span>
     Navigate the site here!
 </span>
+{% if config.extra and config.extra.release_announcement %}
 <span class="right-margin">
     <a href="{{ config.repo_url | trim('/') }}/releases/latest">
         A new release is out — read the release notes
     </a>
 </span>
+{% endif %}
 <span>
     <span class="twemoji">
         {% include ".icons/material/head-question.svg" %}
@@ -26,4 +26,8 @@
         Open a discussion!
     </a>
 </span>
+{% endblock %}
+{% block footer %}
+{% include "partials/ecosystem-links.html" %}
+{{ super() }}
 {% endblock %}

--- a/docs/overrides/partials/ecosystem-links.html
+++ b/docs/overrides/partials/ecosystem-links.html
@@ -1,0 +1,13 @@
+{#- Shared navigation, intentionally separate from site-owned legal text. -#}
+<nav class="hssm-ecosystem-links" aria-label="HSSM ecosystem">
+  <div class="hssm-ecosystem-links__inner">
+    <strong>HSSM ecosystem</strong>
+    <a href="https://lnccbrown.github.io/HSSM/">HSSM</a>
+    <a href="https://lnccbrown.github.io/ssm-simulators/">ssm-simulators</a>
+    <a href="https://lnccbrown.github.io/LANfactory/">LANfactory</a>
+    <a href="https://lnccbrown.github.io/LAN_pipeline_minimal/">LAN pipeline</a>
+    <a href="https://lnccbrown.github.io/HSSMCortex/">HSSMCortex</a>
+    <a href="https://lnccbrown.github.io/HSSMSpine/">HSSMSpine</a>
+    <a href="https://lnccbrown.github.io/HSSM/ecosystem/">Ecosystem map</a>
+  </div>
+</nav>

--- a/docs/styles/extra.css
+++ b/docs/styles/extra.css
@@ -108,3 +108,29 @@ div .md-sidebar__inner nav .md-nav__list {
   width: 35px;
   height: 35px;
 }
+
+/* -- ecosystem navigation (legal text remains in MkDocs copyright) -- */
+.hssm-ecosystem-links {
+  background: var(--md-footer-bg-color);
+  color: var(--md-footer-fg-color);
+}
+
+.hssm-ecosystem-links__inner {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 1rem;
+  align-items: baseline;
+  max-width: 61rem;
+  margin: 0 auto;
+  padding: 0.6rem 0.8rem;
+  font-size: 0.64rem;
+}
+
+.hssm-ecosystem-links__inner a {
+  color: var(--md-footer-fg-color--light);
+}
+
+.hssm-ecosystem-links__inner a:hover,
+.hssm-ecosystem-links__inner a:focus {
+  color: var(--md-accent-fg-color);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/lnccbrown/ssm-simulators
 site_url: https://lnccbrown.github.io/ssm-simulators
 edit_uri: edit/main/docs
 exclude_docs: |
+  overrides/
   snippets/
 
 nav:
@@ -23,6 +24,8 @@ nav:
       - Hand off simulated RLSSM data to HSSM: core_tutorials/rlssm_simulation_hssm_handoff.ipynb
       - Write a custom parameter transform: contributing/add_parameter_adapters.md
       - Track data generation runs with MLflow: core_tutorials/using_mlflow.md
+      - Contribute to ssm-simulators: contributing/README.md
+      - Add a new model: contributing/add_models.md
   - Explanations:
       - What ssm-simulators can do: core_tutorials/tutorial_capabilities.ipynb
       - Simulation vs. analytical solutions (PyDDM): core_tutorials/tutorial_simulators_vs_pyddm.ipynb
@@ -36,10 +39,6 @@ nav:
           - config: api/config.md
           - data generators: api/dataset_generators.md
           - support utils: api/support_utils.md
-  - Contributing:
-      - Overview: contributing/README.md
-      - Add a new model: contributing/add_models.md
-
 validation:
   omitted_files: warn
   absolute_links: warn
@@ -132,14 +131,11 @@ theme:
         icon: material/brightness-4
         name: Switch to automatic mode
 
-copyright: >-
-  Copyright &copy; Brown University —
-  <a href="https://lnccbrown.github.io/HSSM/">HSSM</a> ·
-  <a href="https://lnccbrown.github.io/ssm-simulators/">ssm-simulators</a> ·
-  <a href="https://lnccbrown.github.io/LANfactory/">LANfactory</a>
+copyright: Copyright &copy; 2021 Alexander Fengler. MIT License.
 
 extra:
   homepage: "https://lnccbrown.github.io/ssm-simulators/"
+  release_announcement: true
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/lnccbrown/ssm-simulators

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ docs = [
 
 [project.urls]
 Homepage = "https://github.com/lnccbrown/ssm-simulators"
+Documentation = "https://lnccbrown.github.io/ssm-simulators/"
 "Bug Tracker" = "https://github.com/lnccbrown/ssm-simulators/issues"
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,16 +66,6 @@ dev = [
     "jax>=0.4.20",
     "jaxlib>=0.4.20",
 ]
-docs = [
-    "mkdocs>=1.5.0",
-    "mkdocs-material>=9.5.0",
-    "mkdocs-jupyter>=0.24.0",
-    "mkdocstrings[python]>=1.0.0",
-    # <1.2.3: the 1.2.3 release moved to the ProperDocs mkdocs fork — it
-    # force-installs `properdocs`, caps mkdocs<=1.6.1, and injects an ad
-    # banner into every mkdocs build. 1.2.2 is the last canonical release.
-    "mkdocs-redirects>=1.2.0,<1.2.3",
-]
 
 [dependency-groups]
 dev = [
@@ -99,14 +89,13 @@ dev = [
     "jaxlib>=0.4.20",
 ]
 docs = [
-    "mkdocs>=1.5.0",
-    "mkdocs-material>=9.5.0",
-    "mkdocs-jupyter>=0.24.0",
-    "mkdocstrings[python]>=1.0.0",
-    # <1.2.3: the 1.2.3 release moved to the ProperDocs mkdocs fork — it
-    # force-installs `properdocs`, caps mkdocs<=1.6.1, and injects an ad
-    # banner into every mkdocs build. 1.2.2 is the last canonical release.
-    "mkdocs-redirects>=1.2.0,<1.2.3",
+    "mkdocs==1.6.1",
+    "mkdocs-material==9.7.7",
+    "mkdocs-redirects==1.2.2",
+    "mkdocs-jupyter==0.26.3",
+    "mkdocstrings==1.0.6",
+    "mkdocstrings-python==2.0.5",
+    "mkdocs-autorefs==1.4.4",
 ]
 
 [project.urls]

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+usage() {
+  echo "Usage: ./scripts/docs.sh {build|serve}" >&2
+}
+
+if [ "$#" -ne 1 ]; then
+  usage
+  exit 2
+fi
+
+case "$1" in
+  build | serve)
+    command="$1"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+
+uv sync \
+  --python 3.12 \
+  --no-dev \
+  --group docs \
+  --locked
+
+case "$command" in
+  build)
+    uv run --python 3.12 --no-dev --group docs --no-sync mkdocs build --strict
+    ;;
+  serve)
+    uv run --python 3.12 --no-dev --group docs --no-sync mkdocs serve
+    ;;
+esac

--- a/uv.lock
+++ b/uv.lock
@@ -2364,11 +2364,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/5b/4c1902e8bdd5c4db63284e9d101dece4038d4025d6d88850ffe0a1578980/mkdocstrings-1.0.6-py3-none-any.whl", hash = "sha256:2703708697487d1b6d6d7b412e176fa436edf120c1bf81dc9e126b12d00893c7", size = 35787, upload-time = "2026-07-11T19:38:04.417Z" },
 ]
 
-[package.optional-dependencies]
-python = [
-    { name = "mkdocstrings-python" },
-]
-
 [[package]]
 name = "mkdocstrings-python"
 version = "2.0.5"
@@ -4593,13 +4588,6 @@ dev = [
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
-docs = [
-    { name = "mkdocs" },
-    { name = "mkdocs-jupyter" },
-    { name = "mkdocs-material" },
-    { name = "mkdocs-redirects" },
-    { name = "mkdocstrings", extra = ["python"] },
-]
 jax = [
     { name = "jax" },
     { name = "jaxlib" },
@@ -4651,10 +4639,12 @@ dev = [
 ]
 docs = [
     { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-material" },
     { name = "mkdocs-redirects" },
-    { name = "mkdocstrings", extra = ["python"] },
+    { name = "mkdocstrings" },
+    { name = "mkdocstrings-python" },
 ]
 
 [package.metadata]
@@ -4674,11 +4664,6 @@ requires-dist = [
     { name = "marimo", extras = ["recommended"], marker = "extra == 'dev'" },
     { name = "matplotlib" },
     { name = "maturin", marker = "extra == 'parallel-all'", specifier = ">=1.4" },
-    { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
-    { name = "mkdocs-jupyter", marker = "extra == 'docs'", specifier = ">=0.24.0" },
-    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.0" },
-    { name = "mkdocs-redirects", marker = "extra == 'docs'", specifier = ">=1.2.0,<1.2.3" },
-    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.24.0" },
     { name = "mlflow", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "mlflow", marker = "extra == 'mlflow'", specifier = ">=3.6.0" },
     { name = "mypy", marker = "extra == 'dev'" },
@@ -4708,7 +4693,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.15.3" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
 ]
-provides-extras = ["mlflow", "pyddm", "numba", "jax", "jax-cuda", "parallel", "parallel-all", "dev", "docs"]
+provides-extras = ["mlflow", "pyddm", "numba", "jax", "jax-cuda", "parallel", "parallel-all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4732,11 +4717,13 @@ dev = [
     { name = "ruff", specifier = ">=0.15.1,<0.16" },
 ]
 docs = [
-    { name = "mkdocs", specifier = ">=1.5.0" },
-    { name = "mkdocs-jupyter", specifier = ">=0.24.0" },
-    { name = "mkdocs-material", specifier = ">=9.5.0" },
-    { name = "mkdocs-redirects", specifier = ">=1.2.0,<1.2.3" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.24.0" },
+    { name = "mkdocs", specifier = "==1.6.1" },
+    { name = "mkdocs-autorefs", specifier = "==1.4.4" },
+    { name = "mkdocs-jupyter", specifier = "==0.26.3" },
+    { name = "mkdocs-material", specifier = "==9.7.7" },
+    { name = "mkdocs-redirects", specifier = "==1.2.2" },
+    { name = "mkdocstrings", specifier = "==1.0.6" },
+    { name = "mkdocstrings-python", specifier = "==2.0.5" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- standardize the local documentation interface on `./scripts/docs.sh build|serve`
  with Python 3.12, uv 0.12.2, a locked PEP 735 docs group, and the shared exact
  MkDocs pins
- replace the repository-specific branch deployment with the Spine-authored,
  locally vendored Pages-artifact workflow using the `gsl` system profile and
  source-aware documentation path filters
- make the documentation site canonical for durable guidance, shorten the README,
  retain the structured-observation material merged in #335, and keep all content
  under Home / Learn / How-to guides / Explanations / Reference
- repair 12 rendered-route links in three existing tutorial notebooks without
  changing their code, outputs, or execution state

No simulator API, runtime behavior, scientific example, or generated notebook output
changes in this PR.

## Verification

- `bash -n scripts/docs.sh`
- `./scripts/docs.sh build` with Python 3.12.13 and uv 0.12.2 in the locked docs group
- exact shared pins present; `mkdocs-redirects==1.2.2`; ProperDocs absent
- actionlint 1.7.12 on all workflows
- Spine documentation contract/workflow suite: 43 passed
- reusable workflow and four shared brand files byte-identical to current Spine `main`
- pinned Lychee 0.24.2 over the rendered Pages-path mount: 4,601 links, 0 errors
- notebook inspection: all three edited notebooks executed, 0 errors, 0 path leaks
- `pytest tests/test_notebooks.py --run-notebooks --no-cov -v`: 11 passed
- `ruff format --check .` and `ruff check .`: passed (155 files)
- full Python 3.12 package suite: 1,176 passed, 134 skipped; 94% total coverage
- `git diff --check origin/main...HEAD`

## Rollout

The public URL remains `https://lnccbrown.github.io/ssm-simulators/`. Pages remains on
the preserved `gh-pages` source during review. Immediately before merge, we will allow
`main` in the `github-pages` environment and switch Pages to GitHub Actions. After merge,
we will verify the automatic artifact deployment and a manual-main rendered-link/deploy
run. The existing `gh-pages` branch will remain intact as a rollback reference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Documentation builds and deployments are now automated with scheduled link checks.
  - Added ecosystem navigation links to the documentation footer.
  - Added contribution and model-authoring guidance to the documentation.
  - Added consistent commands for building or previewing documentation locally.

- **Bug Fixes**
  - Corrected tutorial and API links throughout the documentation.
  - Improved link checking with caching, retries, and timeouts.

- **Documentation**
  - Streamlined the README with updated installation, tutorials, development, and contribution guidance.
  - Clarified documentation workflow and drift-check behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->