### PR TITLE
Declare exact choices for legacy configs

### DIFF
--- a/ssms/config/_modelconfig/dev_rlwm_lba.py
+++ b/ssms/config/_modelconfig/dev_rlwm_lba.py
@@ -37,6 +37,7 @@ def get_dev_rlwm_lba_pw_v1_config():
         "n_params": 9,
         "default_params": [0.5, 0.3, 0.2, 0.5, 0.3, 0.2, 0.5, 0.2, 0.1],
         "nchoices": 3,
+        "choices": [0, 1, 2],
         "n_particles": 3,
         "simulator": cssm.rlwm_lba_pw_v1,
         "parameter_transforms": {
@@ -138,6 +139,7 @@ def get_dev_rlwm_lba_race_v2_config():
         "n_params": 8,
         "default_params": [0.5, 0.3, 0.2, 0.5, 0.3, 0.2, 0.5, 0.2],
         "nchoices": 3,
+        "choices": [0, 1, 2],
         "n_particles": 3,
         "simulator": cssm.rlwm_lba_race,
         "parameter_transforms": {

--- a/ssms/config/_modelconfig/lba.py
+++ b/ssms/config/_modelconfig/lba.py
@@ -210,6 +210,7 @@ def get_lba_angle_3_config():
         "n_params": 6,
         "default_params": [0.5, 0.3, 0.2, 0.5, 0.2, 0.0],
         "nchoices": 3,
+        "choices": [0, 1, 2],
         "n_particles": 3,
         "simulator": cssm.lba_angle,
         # Unified parameter_transforms - both sampling and simulation in one place

--- a/ssms/config/_modelconfig/lca.py
+++ b/ssms/config/_modelconfig/lca.py
@@ -26,6 +26,7 @@ def get_lca_3_config():
         "n_params": 10,
         "default_params": [0.0, 0.0, 0.0, 2.0, 0.5, 0.5, 0.5, 0.0, 0.0, 1e-3],
         "nchoices": 3,
+        "choices": [0, 1, 2],
         "n_particles": 3,
         "simulator": cssm.lca,
         "parameter_transforms": {

--- a/ssms/config/_modelconfig/tradeoff.py
+++ b/ssms/config/_modelconfig/tradeoff.py
@@ -97,6 +97,7 @@ def get_tradeoff_weibull_no_bias_config():
         "n_params": 8,
         "default_params": [0.0, 0.0, 0.0, 1.0, 0.5, 1.0, 2.5, 3.5],
         "nchoices": 4,
+        "choices": [0, 1, 2, 3],
         "n_particles": 1,
         "simulator": cssm.ddm_flexbound_tradeoff,
         "parameter_transforms": {

--- a/tests/test_hssm_support.py
+++ b/tests/test_hssm_support.py
@@ -28,6 +28,15 @@ from ssms.hssm_support import (
 )
 
 
+REGISTERED_CHOICE_LABELS = (
+    ("dev_rlwm_lba_pw_v1", [0, 1, 2]),
+    ("dev_rlwm_lba_race_v2", [0, 1, 2]),
+    ("lba_angle_3", [0, 1, 2]),
+    ("lca_3", [0, 1, 2]),
+    ("tradeoff_weibull_no_bias", [0, 1, 2, 3]),
+)
+
+
 class MockHasListParams:
     """Mock class that implements _HasListParams protocol."""
 
@@ -427,6 +436,12 @@ class TestGetSimulatorFunInternal:
         match = "`simulator_fun` must be a string or a callable"
         with pytest.raises(ValueError, match=match):
             get_simulator_fun_internal(123)
+
+    @pytest.mark.parametrize(("model_name", "expected"), REGISTERED_CHOICE_LABELS)
+    def test_registered_choice_labels_reach_hssm_wrapper(self, model_name, expected):
+        contract = validate_simulator_fun(get_simulator_fun_internal(model_name))
+
+        assert contract == (model_name, expected, 2)
 
 
 class TestValidateSimulatorFun:

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -7,6 +7,15 @@ from ssms.config.model_config_builder import ModelConfigBuilder
 from ssms.transforms import SwapIfLessConstraint
 
 
+REGISTERED_CHOICE_LABELS = (
+    ("dev_rlwm_lba_pw_v1", (0, 1, 2)),
+    ("dev_rlwm_lba_race_v2", (0, 1, 2)),
+    ("lba_angle_3", (0, 1, 2)),
+    ("lca_3", (0, 1, 2)),
+    ("tradeoff_weibull_no_bias", (0, 1, 2, 3)),
+)
+
+
 class TestModelConfig:
     def test_model_config_dict_type(self):
         assert isinstance(model_config, ssms.config.CopyOnAccessDict)
@@ -17,6 +26,17 @@ class TestModelConfig:
         list_params = selected_model["params"]
         list_params.append("p_outlier")
         assert "p_outlier" not in model_config[model_name]["params"]
+
+    @pytest.mark.parametrize(("model_name", "expected"), REGISTERED_CHOICE_LABELS)
+    def test_declared_choices_match_simulator_metadata(self, model_name, expected):
+        config = ModelConfigBuilder.from_model(model_name)
+        result = ssms.Simulator(model_name).simulate(
+            config["default_params"], n_samples=1, random_state=42
+        )
+
+        assert tuple(config["choices"]) == expected
+        assert tuple(result["metadata"]["possible_choices"]) == expected
+        assert set(np.unique(result["choices"])).issubset(expected)
 
 
 class TestModelConfigBuilder:


### PR DESCRIPTION
Depends on #337.

## Why

Five built-in model configs declared only a choice count, not their exact response labels. The legacy HSSM wrapper therefore used its three-label fallback. That happened to match four models, but incorrectly exposed the four-choice `tradeoff_weibull_no_bias` model as supporting only `[0, 1, 2]`.

## Scope

- declare `[0, 1, 2]` for the four three-choice configs
- declare `[0, 1, 2, 3]` for `tradeoff_weibull_no_bias`
- verify each declaration against simulator-owned `possible_choices` metadata and observed outputs
- verify the exact labels reach the unchanged three-value HSSM simulator contract

This is a standalone config correction. It does not yet classify observation schemas or change simulator output.

## Verification

- focused config and HSSM-support suite: 106 passed
- simulator, class, and dataset-integration regression slice passed
- HSSM `test_make_hssm_rv` passed with candidate `ssms` provenance confirmed
- repository-wide Ruff check and format check passed
- `git diff --check`
