### PR TITLE
Classify built-in observation producers

### DIFF
--- a/ssms/config/_modelconfig/__init__.py
+++ b/ssms/config/_modelconfig/__init__.py
@@ -143,6 +143,13 @@ from .addm import get_addm_config
 from .validation import get_invalid_configs
 
 
+def _rt_choice(config: dict) -> dict:
+    """Mark an explicitly selected config as a legacy RT/choice producer."""
+    config["observation_schema_version"] = 1
+    config["observation_schema_profile"] = "legacy_rt_choice"
+    return config
+
+
 def _normalize_param_bounds(config: dict) -> dict:
     """Normalize param_bounds to param_bounds_dict format.
 
@@ -191,119 +198,175 @@ def get_model_config():
     """
     # TODO: Refactor to load these lazily
     configs = {
-        "ddm": get_ddm_config(),
-        "ddm_st": get_ddm_st_config(),
-        "ddm_truncnormt": get_ddm_truncnormt_config(),
-        "ddm_rayleight": get_ddm_rayleight_config(),
-        "ddm_sdv": get_ddm_sdv_config(),
-        "ddm_par2": get_ddm_par2_config(),
-        "ddm_par2_no_bias": get_ddm_par2_no_bias_config(),
-        "ddm_par2_conflict_gamma_no_bias": get_ddm_par2_conflict_gamma_no_bias_config(),
-        "ddm_par2_angle_no_bias": get_ddm_par2_angle_no_bias_config(),
-        "ddm_par2_weibull_no_bias": get_ddm_par2_weibull_no_bias_config(),
-        "ddm_seq2": get_ddm_seq2_config(),
-        "ddm_seq2_no_bias": get_ddm_seq2_no_bias_config(),
-        "ddm_seq2_conflict_gamma_no_bias": get_ddm_seq2_conflict_gamma_no_bias_config(),
-        "ddm_seq2_angle_no_bias": get_ddm_seq2_angle_no_bias_config(),
-        "ddm_seq2_weibull_no_bias": get_ddm_seq2_weibull_no_bias_config(),
-        "ddm_mic2_adj": get_ddm_mic2_adj_config(),
-        "ddm_mic2_adj_no_bias": get_ddm_mic2_adj_no_bias_config(),
-        "ddm_mic2_adj_conflict_gamma_no_bias": get_ddm_mic2_adj_conflict_gamma_no_bias_config(),
-        "ddm_mic2_adj_angle_no_bias": get_ddm_mic2_adj_angle_no_bias_config(),
-        "ddm_mic2_adj_weibull_no_bias": get_ddm_mic2_adj_weibull_no_bias_config(),
-        "ddm_mic2_ornstein": get_ddm_mic2_ornstein_config(),
-        "ddm_mic2_ornstein_no_bias": get_ddm_mic2_ornstein_no_bias_config(),
-        "ddm_mic2_ornstein_no_bias_no_lowdim_noise": get_ddm_mic2_ornstein_no_bias_config(),
-        "ddm_mic2_ornstein_conflict_gamma_no_bias": get_ddm_mic2_ornstein_conflict_gamma_no_bias_config(),
-        "ddm_mic2_ornstein_conflict_gamma_no_bias_no_lowdim_noise": get_ddm_mic2_ornstein_conflict_gamma_no_bias_config(),
-        "ddm_mic2_ornstein_angle_no_bias": get_ddm_mic2_ornstein_angle_no_bias_config(),
-        "ddm_mic2_ornstein_angle_no_bias_no_lowdim_noise": get_ddm_mic2_ornstein_angle_no_bias_config(),
-        "ddm_mic2_ornstein_weibull_no_bias": get_ddm_mic2_ornstein_weibull_no_bias_config(),
-        "ddm_mic2_ornstein_weibull_no_bias_no_lowdim_noise": get_ddm_mic2_ornstein_weibull_no_bias_config(),
-        "ddm_mic2_leak": get_ddm_mic2_leak_config(),
-        "ddm_mic2_leak_no_bias": get_ddm_mic2_leak_no_bias_config(),
-        "ddm_mic2_leak_no_bias_no_lowdim_noise": get_ddm_mic2_leak_no_bias_config(),
-        "ddm_mic2_leak_conflict_gamma_no_bias": get_ddm_mic2_leak_conflict_gamma_no_bias_config(),
-        "ddm_mic2_leak_conflict_gamma_no_bias_no_lowdim_noise": get_ddm_mic2_leak_conflict_gamma_no_bias_config(),
-        "ddm_mic2_leak_angle_no_bias": get_ddm_mic2_leak_angle_no_bias_config(),
-        "ddm_mic2_leak_angle_no_bias_no_lowdim_noise": get_ddm_mic2_leak_angle_no_bias_config(),
-        "ddm_mic2_leak_weibull_no_bias": get_ddm_mic2_leak_weibull_no_bias_config(),
-        "ddm_mic2_leak_weibull_no_bias_no_lowdim_noise": get_ddm_mic2_leak_weibull_no_bias_config(),
-        "ddm_mic2_multinoise_no_bias": get_ddm_mic2_multinoise_no_bias_config(),
-        "ddm_mic2_multinoise_conflict_gamma_no_bias": get_ddm_mic2_multinoise_conflict_gamma_no_bias_config(),
-        "ddm_mic2_multinoise_angle_no_bias": get_ddm_mic2_multinoise_angle_no_bias_config(),
-        "ddm_mic2_multinoise_weibull_no_bias": get_ddm_mic2_multinoise_weibull_no_bias_config(),
-        "addm": get_addm_config(),
-        "full_ddm": get_full_ddm_config(),
-        "full_ddm_rv": get_full_ddm_rv_config(),
-        "levy": get_levy_config(),
-        "levy_angle": get_levy_angle_config(),
-        "angle": get_angle_config(),
-        "weibull": get_weibull_config(),
-        "gamma_drift": get_gamma_drift_config(),
+        "ddm": _rt_choice(get_ddm_config()),
+        "ddm_st": _rt_choice(get_ddm_st_config()),
+        "ddm_truncnormt": _rt_choice(get_ddm_truncnormt_config()),
+        "ddm_rayleight": _rt_choice(get_ddm_rayleight_config()),
+        "ddm_sdv": _rt_choice(get_ddm_sdv_config()),
+        "ddm_par2": _rt_choice(get_ddm_par2_config()),
+        "ddm_par2_no_bias": _rt_choice(get_ddm_par2_no_bias_config()),
+        "ddm_par2_conflict_gamma_no_bias": _rt_choice(
+            get_ddm_par2_conflict_gamma_no_bias_config()
+        ),
+        "ddm_par2_angle_no_bias": _rt_choice(get_ddm_par2_angle_no_bias_config()),
+        "ddm_par2_weibull_no_bias": _rt_choice(get_ddm_par2_weibull_no_bias_config()),
+        "ddm_seq2": _rt_choice(get_ddm_seq2_config()),
+        "ddm_seq2_no_bias": _rt_choice(get_ddm_seq2_no_bias_config()),
+        "ddm_seq2_conflict_gamma_no_bias": _rt_choice(
+            get_ddm_seq2_conflict_gamma_no_bias_config()
+        ),
+        "ddm_seq2_angle_no_bias": _rt_choice(get_ddm_seq2_angle_no_bias_config()),
+        "ddm_seq2_weibull_no_bias": _rt_choice(get_ddm_seq2_weibull_no_bias_config()),
+        "ddm_mic2_adj": _rt_choice(get_ddm_mic2_adj_config()),
+        "ddm_mic2_adj_no_bias": _rt_choice(get_ddm_mic2_adj_no_bias_config()),
+        "ddm_mic2_adj_conflict_gamma_no_bias": _rt_choice(
+            get_ddm_mic2_adj_conflict_gamma_no_bias_config()
+        ),
+        "ddm_mic2_adj_angle_no_bias": _rt_choice(
+            get_ddm_mic2_adj_angle_no_bias_config()
+        ),
+        "ddm_mic2_adj_weibull_no_bias": _rt_choice(
+            get_ddm_mic2_adj_weibull_no_bias_config()
+        ),
+        "ddm_mic2_ornstein": _rt_choice(get_ddm_mic2_ornstein_config()),
+        "ddm_mic2_ornstein_no_bias": _rt_choice(get_ddm_mic2_ornstein_no_bias_config()),
+        "ddm_mic2_ornstein_no_bias_no_lowdim_noise": (
+            _rt_choice(get_ddm_mic2_ornstein_no_bias_config())
+        ),
+        "ddm_mic2_ornstein_conflict_gamma_no_bias": (
+            _rt_choice(get_ddm_mic2_ornstein_conflict_gamma_no_bias_config())
+        ),
+        "ddm_mic2_ornstein_conflict_gamma_no_bias_no_lowdim_noise": (
+            _rt_choice(get_ddm_mic2_ornstein_conflict_gamma_no_bias_config())
+        ),
+        "ddm_mic2_ornstein_angle_no_bias": _rt_choice(
+            get_ddm_mic2_ornstein_angle_no_bias_config()
+        ),
+        "ddm_mic2_ornstein_angle_no_bias_no_lowdim_noise": (
+            _rt_choice(get_ddm_mic2_ornstein_angle_no_bias_config())
+        ),
+        "ddm_mic2_ornstein_weibull_no_bias": _rt_choice(
+            get_ddm_mic2_ornstein_weibull_no_bias_config()
+        ),
+        "ddm_mic2_ornstein_weibull_no_bias_no_lowdim_noise": (
+            _rt_choice(get_ddm_mic2_ornstein_weibull_no_bias_config())
+        ),
+        "ddm_mic2_leak": _rt_choice(get_ddm_mic2_leak_config()),
+        "ddm_mic2_leak_no_bias": _rt_choice(get_ddm_mic2_leak_no_bias_config()),
+        "ddm_mic2_leak_no_bias_no_lowdim_noise": _rt_choice(
+            get_ddm_mic2_leak_no_bias_config()
+        ),
+        "ddm_mic2_leak_conflict_gamma_no_bias": _rt_choice(
+            get_ddm_mic2_leak_conflict_gamma_no_bias_config()
+        ),
+        "ddm_mic2_leak_conflict_gamma_no_bias_no_lowdim_noise": (
+            _rt_choice(get_ddm_mic2_leak_conflict_gamma_no_bias_config())
+        ),
+        "ddm_mic2_leak_angle_no_bias": _rt_choice(
+            get_ddm_mic2_leak_angle_no_bias_config()
+        ),
+        "ddm_mic2_leak_angle_no_bias_no_lowdim_noise": (
+            _rt_choice(get_ddm_mic2_leak_angle_no_bias_config())
+        ),
+        "ddm_mic2_leak_weibull_no_bias": _rt_choice(
+            get_ddm_mic2_leak_weibull_no_bias_config()
+        ),
+        "ddm_mic2_leak_weibull_no_bias_no_lowdim_noise": (
+            _rt_choice(get_ddm_mic2_leak_weibull_no_bias_config())
+        ),
+        "ddm_mic2_multinoise_no_bias": _rt_choice(
+            get_ddm_mic2_multinoise_no_bias_config()
+        ),
+        "ddm_mic2_multinoise_conflict_gamma_no_bias": (
+            _rt_choice(get_ddm_mic2_multinoise_conflict_gamma_no_bias_config())
+        ),
+        "ddm_mic2_multinoise_angle_no_bias": _rt_choice(
+            get_ddm_mic2_multinoise_angle_no_bias_config()
+        ),
+        "ddm_mic2_multinoise_weibull_no_bias": _rt_choice(
+            get_ddm_mic2_multinoise_weibull_no_bias_config()
+        ),
+        "addm": _rt_choice(get_addm_config()),
+        "full_ddm": _rt_choice(get_full_ddm_config()),
+        "full_ddm_rv": _rt_choice(get_full_ddm_rv_config()),
+        "levy": _rt_choice(get_levy_config()),
+        "levy_angle": _rt_choice(get_levy_angle_config()),
+        "angle": _rt_choice(get_angle_config()),
+        "weibull": _rt_choice(get_weibull_config()),
+        "gamma_drift": _rt_choice(get_gamma_drift_config()),
         "inv_temp_softmax_2": get_inv_temp_softmax_2_config(),
         "inv_temp_softmax_3": get_inv_temp_softmax_3_config(),
         "inv_temp_softmax_4": get_inv_temp_softmax_4_config(),
-        "shrink_spot": get_shrink_spot_config(),
-        "shrink_spot_extended": get_shrink_spot_extended_config(),
-        "shrink_spot_simple": get_shrink_spot_simple_config(),
-        "shrink_spot_simple_extended": get_shrink_spot_simple_extended_config(),
-        "gamma_drift_angle": get_gamma_drift_angle_config(),
-        "conflict_ds": get_conflict_ds_config(),
-        "conflict_ds_angle": get_conflict_ds_angle_config(),
-        "conflict_dsstimflex": get_conflict_dsstimflex_config(),
-        "conflict_dsstimflex_angle": get_conflict_dsstimflex_angle_config(),
-        "conflict_stimflex": get_conflict_stimflex_config(),
-        "conflict_stimflex_angle": get_conflict_stimflex_angle_config(),
-        "conflict_stimflexrel1": get_conflict_stimflexrel1_config(),
-        "conflict_stimflexrel1_angle": get_conflict_stimflexrel1_angle_config(),
-        "conflict_stimflexrel1_leak": get_conflict_stimflexrel1_leak_config(),
-        "conflict_stimflexrel1_leak2": get_conflict_stimflexrel1_leak2_config(),
-        "ornstein": get_ornstein_config(),
-        "ornstein_angle": get_ornstein_angle_config(),
-        "race_2": get_race_2_config(),
-        "race_no_bias_2": get_race_no_bias_2_config(),
-        "race_no_z_2": get_race_no_z_2_config(),
-        "race_no_bias_angle_2": get_race_no_bias_angle_2_config(),
-        "race_no_z_angle_2": get_race_no_z_angle_2_config(),
-        "race_3": get_race_3_config(),
-        "race_no_bias_3": get_race_no_bias_3_config(),
-        "race_no_z_3": get_race_no_z_3_config(),
-        "race_no_bias_angle_3": get_race_no_bias_angle_3_config(),
-        "race_no_z_angle_3": get_race_no_z_angle_3_config(),
-        "race_4": get_race_4_config(),
-        "race_no_bias_4": get_race_no_bias_4_config(),
-        "race_no_z_4": get_race_no_z_4_config(),
-        "race_no_bias_angle_4": get_race_no_bias_angle_4_config(),
-        "race_no_z_angle_4": get_race_no_z_angle_4_config(),
-        "racing_diffusion_3": get_racing_diffusion_3_config(),
-        "poisson_race": get_poisson_race_config(),
-        "dev_rlwm_lba_pw_v1": get_dev_rlwm_lba_pw_v1_config(),
-        "dev_rlwm_lba_race_v1": get_dev_rlwm_lba_race_v1_config(),
-        "dev_rlwm_lba_race_v2": get_dev_rlwm_lba_race_v2_config(),
-        "lba2": get_lba2_config(),
-        "lba3": get_lba3_config(),
-        "lba4": get_lba4_config(),
-        "lba_3_vs_constraint": get_lba_3_vs_constraint_config(),
-        "lba_angle_3_vs_constraint": get_lba_angle_3_vs_constraint_config(),
-        "lba_angle_3": get_lba_angle_3_config(),
-        "lca_3": get_lca_3_config(),
-        "lca_no_bias_3": get_lca_no_bias_3_config(),
-        "lca_no_z_3": get_lca_no_z_3_config(),
-        "lca_no_bias_angle_3": get_lca_no_bias_angle_3_config(),
-        "lca_no_z_angle_3": get_lca_no_z_angle_3_config(),
-        "lca_4": get_lca_4_config(),
-        "lca_no_bias_4": get_lca_no_bias_4_config(),
-        "lca_no_z_4": get_lca_no_z_4_config(),
-        "lca_no_bias_angle_4": get_lca_no_bias_angle_4_config(),
-        "lca_no_z_angle_4": get_lca_no_z_angle_4_config(),
-        "tradeoff_no_bias": get_tradeoff_no_bias_config(),
-        "tradeoff_angle_no_bias": get_tradeoff_angle_no_bias_config(),
-        "tradeoff_weibull_no_bias": get_tradeoff_weibull_no_bias_config(),
-        "tradeoff_conflict_gamma_no_bias": get_tradeoff_conflict_gamma_no_bias_config(),
-        "weibull_cdf": get_weibull_config(),
-        "full_ddm2": get_full_ddm_config(),
-        "ddm_legacy": get_ddm_legacy_config(),
+        "shrink_spot": _rt_choice(get_shrink_spot_config()),
+        "shrink_spot_extended": _rt_choice(get_shrink_spot_extended_config()),
+        "shrink_spot_simple": _rt_choice(get_shrink_spot_simple_config()),
+        "shrink_spot_simple_extended": _rt_choice(
+            get_shrink_spot_simple_extended_config()
+        ),
+        "gamma_drift_angle": _rt_choice(get_gamma_drift_angle_config()),
+        "conflict_ds": _rt_choice(get_conflict_ds_config()),
+        "conflict_ds_angle": _rt_choice(get_conflict_ds_angle_config()),
+        "conflict_dsstimflex": _rt_choice(get_conflict_dsstimflex_config()),
+        "conflict_dsstimflex_angle": _rt_choice(get_conflict_dsstimflex_angle_config()),
+        "conflict_stimflex": _rt_choice(get_conflict_stimflex_config()),
+        "conflict_stimflex_angle": _rt_choice(get_conflict_stimflex_angle_config()),
+        "conflict_stimflexrel1": _rt_choice(get_conflict_stimflexrel1_config()),
+        "conflict_stimflexrel1_angle": _rt_choice(
+            get_conflict_stimflexrel1_angle_config()
+        ),
+        "conflict_stimflexrel1_leak": _rt_choice(
+            get_conflict_stimflexrel1_leak_config()
+        ),
+        "conflict_stimflexrel1_leak2": _rt_choice(
+            get_conflict_stimflexrel1_leak2_config()
+        ),
+        "ornstein": _rt_choice(get_ornstein_config()),
+        "ornstein_angle": _rt_choice(get_ornstein_angle_config()),
+        "race_2": _rt_choice(get_race_2_config()),
+        "race_no_bias_2": _rt_choice(get_race_no_bias_2_config()),
+        "race_no_z_2": _rt_choice(get_race_no_z_2_config()),
+        "race_no_bias_angle_2": _rt_choice(get_race_no_bias_angle_2_config()),
+        "race_no_z_angle_2": _rt_choice(get_race_no_z_angle_2_config()),
+        "race_3": _rt_choice(get_race_3_config()),
+        "race_no_bias_3": _rt_choice(get_race_no_bias_3_config()),
+        "race_no_z_3": _rt_choice(get_race_no_z_3_config()),
+        "race_no_bias_angle_3": _rt_choice(get_race_no_bias_angle_3_config()),
+        "race_no_z_angle_3": _rt_choice(get_race_no_z_angle_3_config()),
+        "race_4": _rt_choice(get_race_4_config()),
+        "race_no_bias_4": _rt_choice(get_race_no_bias_4_config()),
+        "race_no_z_4": _rt_choice(get_race_no_z_4_config()),
+        "race_no_bias_angle_4": _rt_choice(get_race_no_bias_angle_4_config()),
+        "race_no_z_angle_4": _rt_choice(get_race_no_z_angle_4_config()),
+        "racing_diffusion_3": _rt_choice(get_racing_diffusion_3_config()),
+        "poisson_race": _rt_choice(get_poisson_race_config()),
+        "dev_rlwm_lba_pw_v1": _rt_choice(get_dev_rlwm_lba_pw_v1_config()),
+        "dev_rlwm_lba_race_v1": _rt_choice(get_dev_rlwm_lba_race_v1_config()),
+        "dev_rlwm_lba_race_v2": _rt_choice(get_dev_rlwm_lba_race_v2_config()),
+        "lba2": _rt_choice(get_lba2_config()),
+        "lba3": _rt_choice(get_lba3_config()),
+        "lba4": _rt_choice(get_lba4_config()),
+        "lba_3_vs_constraint": _rt_choice(get_lba_3_vs_constraint_config()),
+        "lba_angle_3_vs_constraint": _rt_choice(get_lba_angle_3_vs_constraint_config()),
+        "lba_angle_3": _rt_choice(get_lba_angle_3_config()),
+        "lca_3": _rt_choice(get_lca_3_config()),
+        "lca_no_bias_3": _rt_choice(get_lca_no_bias_3_config()),
+        "lca_no_z_3": _rt_choice(get_lca_no_z_3_config()),
+        "lca_no_bias_angle_3": _rt_choice(get_lca_no_bias_angle_3_config()),
+        "lca_no_z_angle_3": _rt_choice(get_lca_no_z_angle_3_config()),
+        "lca_4": _rt_choice(get_lca_4_config()),
+        "lca_no_bias_4": _rt_choice(get_lca_no_bias_4_config()),
+        "lca_no_z_4": _rt_choice(get_lca_no_z_4_config()),
+        "lca_no_bias_angle_4": _rt_choice(get_lca_no_bias_angle_4_config()),
+        "lca_no_z_angle_4": _rt_choice(get_lca_no_z_angle_4_config()),
+        "tradeoff_no_bias": _rt_choice(get_tradeoff_no_bias_config()),
+        "tradeoff_angle_no_bias": _rt_choice(get_tradeoff_angle_no_bias_config()),
+        "tradeoff_weibull_no_bias": _rt_choice(get_tradeoff_weibull_no_bias_config()),
+        "tradeoff_conflict_gamma_no_bias": _rt_choice(
+            get_tradeoff_conflict_gamma_no_bias_config()
+        ),
+        "weibull_cdf": _rt_choice(get_weibull_config()),
+        "full_ddm2": _rt_choice(get_full_ddm_config()),
+        "ddm_legacy": _rt_choice(get_ddm_legacy_config()),
     }
 
     # Normalize all configs to include param_bounds_dict

--- a/ssms/config/_modelconfig/inv_temp_softmax.py
+++ b/ssms/config/_modelconfig/inv_temp_softmax.py
@@ -21,6 +21,14 @@ def _get_inv_temp_softmax_config(n_choices: int) -> dict:
         "default_params": [1.0, *([0.5] * n_choices)],
         "nchoices": n_choices,
         "choices": list(range(n_choices)),
+        "observation_schema_version": 1,
+        "observation_schema": (
+            {
+                "name": "response",
+                "kind": "categorical",
+                "values": tuple(range(n_choices)),
+            },
+        ),
         "n_particles": 1,
         "tags": ["choice_only_rl"],
         "simulator": inv_temp_softmax,

--- a/tests/test_observation_producer_registry.py
+++ b/tests/test_observation_producer_registry.py
@@ -1,0 +1,137 @@
+"""Focused facts for built-in producer observation metadata."""
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from ssms.basic_simulators import get_observation_metadata
+from ssms.config import ModelConfigBuilder
+from ssms.config._modelconfig import get_model_config
+
+
+CHOICE_ONLY_MODELS = {
+    "inv_temp_softmax_2",
+    "inv_temp_softmax_3",
+    "inv_temp_softmax_4",
+}
+ALIASES_WITH_INTERNAL_NAMES = {
+    "ddm_mic2_ornstein_no_bias_no_lowdim_noise": "ddm_mic2_ornstein_no_bias",
+    "ddm_mic2_ornstein_conflict_gamma_no_bias_no_lowdim_noise": (
+        "ddm_mic2_ornstein_conflict_gamma_no_bias"
+    ),
+    "ddm_mic2_ornstein_angle_no_bias_no_lowdim_noise": (
+        "ddm_mic2_ornstein_angle_no_bias"
+    ),
+    "ddm_mic2_ornstein_weibull_no_bias_no_lowdim_noise": (
+        "ddm_mic2_ornstein_weibull_no_bias"
+    ),
+    "ddm_mic2_leak_no_bias_no_lowdim_noise": "ddm_mic2_leak_no_bias",
+    "ddm_mic2_leak_conflict_gamma_no_bias_no_lowdim_noise": (
+        "ddm_mic2_leak_conflict_gamma_no_bias"
+    ),
+    "ddm_mic2_leak_angle_no_bias_no_lowdim_noise": ("ddm_mic2_leak_angle_no_bias"),
+    "ddm_mic2_leak_weibull_no_bias_no_lowdim_noise": ("ddm_mic2_leak_weibull_no_bias"),
+    "shrink_spot_extended": "shrink_spot",
+    "weibull_cdf": "weibull",
+    "full_ddm2": "full_ddm",
+}
+RT = {
+    "name": "rt",
+    "kind": "continuous",
+    "lower": 0.0,
+    "lower_inclusive": False,
+}
+
+
+def _descriptor(*fields: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "observation_schema_version": 1,
+        "observation_schema": fields,
+        "obs_dim": len(fields),
+    }
+
+
+def _response(values: tuple[int, ...]) -> dict[str, Any]:
+    return {"name": "response", "kind": "categorical", "values": values}
+
+
+def test_all_raw_builtin_configs_are_explicitly_classified() -> None:
+    configs = get_model_config()
+    explicit = {
+        name for name, config in configs.items() if "observation_schema" in config
+    }
+    profiled = {
+        name
+        for name, config in configs.items()
+        if "observation_schema_profile" in config
+    }
+
+    assert explicit == CHOICE_ONLY_MODELS
+    assert len(profiled) == 110
+    assert explicit.isdisjoint(profiled)
+    assert explicit | profiled == set(configs)
+    assert {config["observation_schema_version"] for config in configs.values()} == {1}
+    assert {configs[name]["observation_schema_profile"] for name in profiled} == {
+        "legacy_rt_choice"
+    }
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected"),
+    [
+        ("ddm", _descriptor(RT, _response((-1, 1)))),
+        ("race_3", _descriptor(RT, _response((0, 1, 2)))),
+        ("lba4", _descriptor(RT, _response((0, 1, 2, 3)))),
+        ("inv_temp_softmax_2", _descriptor(_response((0, 1)))),
+        ("inv_temp_softmax_3", _descriptor(_response((0, 1, 2)))),
+        ("inv_temp_softmax_4", _descriptor(_response((0, 1, 2, 3)))),
+    ],
+)
+def test_representative_builtin_semantics_are_exact(
+    model_name: str, expected: dict[str, Any]
+) -> None:
+    config = ModelConfigBuilder.from_model(model_name)
+
+    assert get_observation_metadata(config) == expected
+
+
+def test_registry_aliases_are_classified_despite_internal_names() -> None:
+    configs = get_model_config()
+    aliases = {
+        name: config["name"]
+        for name, config in configs.items()
+        if name != config["name"]
+    }
+
+    assert aliases == ALIASES_WITH_INTERNAL_NAMES
+    for registry_name, internal_name in aliases.items():
+        config = ModelConfigBuilder.from_model(registry_name)
+        assert config["name"] == internal_name
+        assert get_observation_metadata(config) == _descriptor(
+            RT, _response(tuple(config["choices"]))
+        )
+
+
+def test_deadline_builder_inherits_observation_classification() -> None:
+    base = ModelConfigBuilder.from_model("ddm")
+    deadline = ModelConfigBuilder.from_model("ddm_deadline")
+
+    assert deadline["observation_schema_version"] == base["observation_schema_version"]
+    assert deadline["observation_schema_profile"] == base["observation_schema_profile"]
+    assert get_observation_metadata(deadline) == _descriptor(RT, _response((-1, 1)))
+
+
+def test_custom_config_fails_closed_without_explicit_classification() -> None:
+    def custom_simulator() -> None:
+        return None
+
+    config = ModelConfigBuilder.minimal_config(
+        params=[], simulator_function=custom_simulator, nchoices=4
+    )
+    config["observation_schema_version"] = 1
+    config["obs_dim"] = 2
+
+    assert config["choices"] == [0, 1, 2, 3]
+    with pytest.raises(ValueError, match="exactly one"):
+        get_observation_metadata(config)


### PR DESCRIPTION
Depends on #338.

## Scope

- mark each existing RT/choice producer explicitly with the version-1 `legacy_rt_choice` profile
- declare the three inverse-temperature softmax producers as response-only schemas
- cover representative binary, three-choice, four-choice, alias, deadline, and fail-closed cases

The call-site wrappers are intentional: the existing registry enumeration is the allowlist, so a future model is not classified from `nchoices`, tags, simulator identity, or an "all except" default. Contributors must choose a profile or provide an explicit schema.

## Compatibility

- no simulator output, shape, signature, result metadata, dependency, or lockfile changes
- the inverse-temperature softmax dummy RT remains in the legacy result and is only excluded from the semantic observation descriptor
- schema lookup and HSSM wrapper exposure remain isolated to the next stacked PR

## Verification

- focused classification/config/RL suite: 84 passed
- focused config-factory coverage: 100%
- Ruff check and format check passed
- `git diff --check`
