### PR TITLE
Expose observation metadata through simulator interfaces

### DIFF
--- a/ssms/basic_simulators/observation_metadata.py
+++ b/ssms/basic_simulators/observation_metadata.py
@@ -1,6 +1,6 @@
 """Validate and inspect explicit producer observation metadata."""
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from numbers import Integral
 from typing import Any
 
@@ -51,19 +51,30 @@ def validate_observation_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]
     }
 
 
-def get_observation_metadata(
-    producer: Mapping[str, Any] | Callable[..., Any],
-) -> dict[str, Any]:
-    """Return explicit observation metadata for a mapping or callable producer.
+def get_observation_metadata(producer: object) -> dict[str, Any]:
+    """Return explicit observation metadata for a producer.
 
+    Model names are resolved from the live registry without running their simulators.
+    Objects may provide a zero-argument ``get_observation_metadata`` hook.
     Callable producers are inspected through the explicit schema attributes only and
     are never executed. Their legacy ``obs_dim`` attribute is deliberately ignored:
     semantic width always comes from the declared schema.
     """
+    if isinstance(producer, str):
+        from ssms.config import ModelConfigBuilder
+
+        return validate_observation_metadata(ModelConfigBuilder.from_model(producer))
     if isinstance(producer, Mapping):
         return validate_observation_metadata(producer)
+
+    provider = getattr(producer, "get_observation_metadata", None)
+    if callable(provider):
+        return validate_observation_metadata(provider())
     if not callable(producer):
-        raise TypeError("producer must be an observation metadata mapping or callable")
+        raise TypeError(
+            "producer must be a model name, observation metadata mapping or callable, "
+            "or expose get_observation_metadata()"
+        )
 
     metadata = _callable_metadata(producer)
     if not {

--- a/ssms/basic_simulators/simulator_class.py
+++ b/ssms/basic_simulators/simulator_class.py
@@ -10,10 +10,14 @@ import inspect
 import warnings
 from collections.abc import Callable
 from copy import deepcopy
+from typing import Any
 
 import numpy as np
 import pandas as pd
 
+from ssms.basic_simulators.observation_metadata import (
+    get_observation_metadata as _get_observation_metadata,
+)
 from ssms.basic_simulators.simulator import (
     _get_unique_seed,
     _preprocess_theta_deadline,
@@ -697,6 +701,10 @@ class Simulator:
         """
         model_name = self._config.get("name", "")
         validate_ssm_parameters(model_name, theta)
+
+    def get_observation_metadata(self) -> dict[str, Any]:
+        """Return fresh validated metadata for this simulator's observations."""
+        return _get_observation_metadata(self._config)
 
     @property
     def config(self) -> dict:

--- a/ssms/hssm_support.py
+++ b/ssms/hssm_support.py
@@ -1,11 +1,13 @@
+from copy import deepcopy
 from functools import partial
-from typing import Any, Callable, cast
 import logging
+from typing import Any, Callable, cast
 
 import numpy as np
 
+from .basic_simulators.observation_metadata import validate_observation_metadata
 from .basic_simulators.simulator import simulator
-from .config import model_config as ssms_model_config
+from .config import get_model_registry
 
 
 _logger = logging.getLogger(__name__)
@@ -330,7 +332,10 @@ def get_simulator_fun_internal(simulator_fun: Callable | str):
         return cast("Callable[..., Any]", simulator_fun)
 
     simulator_fun_str = simulator_fun
-    if simulator_fun_str not in ssms_model_config:
+    registry = get_model_registry()
+    if registry.has_model(simulator_fun_str):
+        config = deepcopy(registry.get(simulator_fun_str))
+    else:
         _logger.warning(
             "You supplied a model '%s', which is currently not supported in "
             "the ssm_simulators package. An error will be thrown when sampling "
@@ -338,12 +343,32 @@ def get_simulator_fun_internal(simulator_fun: Callable | str):
             "posterior or prior predictive sampling methods.",
             simulator_fun_str,
         )
-    choices = ssms_model_config.get(simulator_fun_str, {}).get("choices", [0, 1, 2])
+        config = {}
+    choices = deepcopy(config.get("choices", [0, 1, 2]))
     simulator_fun_internal = _build_decorated_simulator(
         model_name=simulator_fun_str,
         choices=choices,
     )
+    _attach_observation_metadata(simulator_fun_internal, config)
     return simulator_fun_internal
+
+
+def _attach_observation_metadata(
+    simulator_fun: Callable[..., Any], config: dict[str, Any]
+) -> None:
+    """Attach validated schema declarations without changing the legacy wrapper."""
+    try:
+        validate_observation_metadata(config)
+    except (TypeError, ValueError):
+        return
+
+    for name in (
+        "observation_schema_version",
+        "observation_schema",
+        "observation_schema_profile",
+    ):
+        if name in config:
+            setattr(simulator_fun, name, deepcopy(config[name]))
 
 
 def validate_simulator_fun(simulator_fun: Any) -> tuple[str, list, int]:

--- a/ssms/hssm_support.py
+++ b/ssms/hssm_support.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from .basic_simulators.observation_metadata import validate_observation_metadata
 from .basic_simulators.simulator import simulator
-from .config import get_model_registry
+from .config import ModelConfigBuilder, get_model_registry
 
 
 _logger = logging.getLogger(__name__)
@@ -333,8 +333,13 @@ def get_simulator_fun_internal(simulator_fun: Callable | str):
 
     simulator_fun_str = simulator_fun
     registry = get_model_registry()
-    if registry.has_model(simulator_fun_str):
-        config = deepcopy(registry.get(simulator_fun_str))
+    base_model = (
+        simulator_fun_str.replace("_deadline", "")
+        if "_deadline" in simulator_fun_str
+        else simulator_fun_str
+    )
+    if registry.has_model(base_model):
+        config = ModelConfigBuilder.from_model(simulator_fun_str)
     else:
         _logger.warning(
             "You supplied a model '%s', which is currently not supported in "

--- a/tests/test_hssm_support.py
+++ b/tests/test_hssm_support.py
@@ -1,6 +1,7 @@
 """Tests for ssms.hssm_support module."""
 
 import random
+from threading import Lock
 
 import numpy as np
 import pytest
@@ -400,19 +401,24 @@ class TestGetSimulatorFunInternal:
         assert result is mock_simulator
 
     @patch("ssms.hssm_support.get_model_registry")
+    @patch("ssms.hssm_support.ModelConfigBuilder")
     @patch("ssms.hssm_support._build_decorated_simulator")
     def test_get_simulator_fun_internal_string_known_model(
-        self, mock_build, mock_get_registry
+        self, mock_build, mock_builder, mock_get_registry
     ):
         """Test get_simulator_fun_internal with known model string."""
         registry = mock_get_registry.return_value
         registry.has_model.return_value = True
-        registry.get.return_value = {"choices": [0, 1]}
+        mock_builder.from_model.return_value = {
+            "choices": [0, 1],
+            # Unrelated config extensions may hold non-copyable runtime state.
+            "runtime_extension": Lock(),
+        }
         mock_build.return_value = Mock()
 
         result = get_simulator_fun_internal("ddm")
 
-        registry.get.assert_called_once_with("ddm")
+        mock_builder.from_model.assert_called_once_with("ddm")
         mock_build.assert_called_once_with(model_name="ddm", choices=[0, 1])
         assert result == mock_build.return_value
 
@@ -434,6 +440,17 @@ class TestGetSimulatorFunInternal:
             model_name="unknown_model", choices=[0, 1, 2]
         )
 
+    @patch("ssms.hssm_support.get_model_registry")
+    @patch("ssms.hssm_support.ModelConfigBuilder")
+    def test_registered_model_resolution_errors_propagate(
+        self, mock_builder, mock_get_registry
+    ):
+        mock_get_registry.return_value.has_model.return_value = True
+        mock_builder.from_model.side_effect = ValueError("broken config")
+
+        with pytest.raises(ValueError, match="broken config"):
+            get_simulator_fun_internal("broken")
+
     def test_get_simulator_fun_internal_invalid_type(self):
         """Test get_simulator_fun_internal with invalid type."""
         match = "`simulator_fun` must be a string or a callable"
@@ -445,6 +462,18 @@ class TestGetSimulatorFunInternal:
         contract = validate_simulator_fun(get_simulator_fun_internal(model_name))
 
         assert contract == (model_name, expected, 2)
+
+    @pytest.mark.parametrize(
+        ("model_name", "expected_choices"),
+        [("ddm_deadline", [-1, 1]), ("lba2_deadline", [0, 1])],
+    )
+    def test_derived_deadline_wrapper_uses_base_model_metadata(
+        self, model_name, expected_choices
+    ):
+        wrapper = get_simulator_fun_internal(model_name)
+
+        assert validate_simulator_fun(wrapper) == (model_name, expected_choices, 2)
+        assert get_observation_metadata(wrapper) == get_observation_metadata(model_name)
 
     def test_registered_wrapper_exposes_semantic_observation_metadata(self):
         rt_choice = get_simulator_fun_internal("ddm")
@@ -489,12 +518,13 @@ class TestGetSimulatorFunInternal:
             get_observation_metadata(wrapper)
 
     @patch("ssms.hssm_support.get_model_registry")
+    @patch("ssms.hssm_support.ModelConfigBuilder")
     def test_incomplete_profile_does_not_gain_choices_from_fallback(
-        self, mock_get_registry
+        self, mock_builder, mock_get_registry
     ):
         registry = mock_get_registry.return_value
         registry.has_model.return_value = True
-        registry.get.return_value = {
+        mock_builder.from_model.return_value = {
             "observation_schema_version": 1,
             "observation_schema_profile": "legacy_rt_choice",
         }

--- a/tests/test_hssm_support.py
+++ b/tests/test_hssm_support.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 from unittest.mock import Mock, patch
 
+from ssms.basic_simulators import get_observation_metadata
 from ssms.basic_simulators.simulator import (
     _RNG_SEED_C_LONG_MAX,
     _validate_random_state_for_c_rng,
@@ -398,30 +399,32 @@ class TestGetSimulatorFunInternal:
         result = get_simulator_fun_internal(mock_simulator)
         assert result is mock_simulator
 
-    @patch("ssms.hssm_support.ssms_model_config")
+    @patch("ssms.hssm_support.get_model_registry")
     @patch("ssms.hssm_support._build_decorated_simulator")
     def test_get_simulator_fun_internal_string_known_model(
-        self, mock_build, mock_config
+        self, mock_build, mock_get_registry
     ):
         """Test get_simulator_fun_internal with known model string."""
-        mock_config.__contains__ = Mock(return_value=True)
-        mock_config.get = Mock(return_value={"choices": [0, 1]})
+        registry = mock_get_registry.return_value
+        registry.has_model.return_value = True
+        registry.get.return_value = {"choices": [0, 1]}
         mock_build.return_value = Mock()
 
         result = get_simulator_fun_internal("ddm")
 
+        registry.get.assert_called_once_with("ddm")
         mock_build.assert_called_once_with(model_name="ddm", choices=[0, 1])
         assert result == mock_build.return_value
 
-    @patch("ssms.hssm_support.ssms_model_config")
+    @patch("ssms.hssm_support.get_model_registry")
     @patch("ssms.hssm_support._build_decorated_simulator")
     @patch("ssms.hssm_support._logger")
     def test_get_simulator_fun_internal_string_unknown_model(
-        self, mock_logger, mock_build, mock_config
+        self, mock_logger, mock_build, mock_get_registry
     ):
         """Test get_simulator_fun_internal with unknown model string."""
-        mock_config.__contains__ = Mock(return_value=False)
-        mock_config.get = Mock(return_value={"choices": [0, 1, 2]})
+        registry = mock_get_registry.return_value
+        registry.has_model.return_value = False
         mock_build.return_value = Mock()
 
         get_simulator_fun_internal("unknown_model")
@@ -442,6 +445,71 @@ class TestGetSimulatorFunInternal:
         contract = validate_simulator_fun(get_simulator_fun_internal(model_name))
 
         assert contract == (model_name, expected, 2)
+
+    def test_registered_wrapper_exposes_semantic_observation_metadata(self):
+        rt_choice = get_simulator_fun_internal("ddm")
+        response_only = get_simulator_fun_internal("inv_temp_softmax_3")
+        raw_response_only = response_only(
+            theta=np.asarray([1.0, 0.5, 0.5, 0.5]),
+            n_replicas=4,
+            random_state=42,
+        )
+
+        assert validate_simulator_fun(rt_choice) == ("ddm", [-1, 1], 2)
+        assert get_observation_metadata(rt_choice)["obs_dim"] == 2
+        assert validate_simulator_fun(response_only) == (
+            "inv_temp_softmax_3",
+            [0, 1, 2],
+            2,
+        )
+        assert get_observation_metadata(response_only) == {
+            "observation_schema_version": 1,
+            "observation_schema": (
+                {
+                    "name": "response",
+                    "kind": "categorical",
+                    "values": (0, 1, 2),
+                },
+            ),
+            "obs_dim": 1,
+        }
+        assert raw_response_only.shape == (4, 2)
+        assert np.all(raw_response_only[:, 0] == -1)
+
+    @patch("ssms.hssm_support._logger")
+    def test_unknown_wrapper_does_not_gain_schema_from_fallback(self, _mock_logger):
+        wrapper = get_simulator_fun_internal("not_a_registered_model")
+
+        assert validate_simulator_fun(wrapper) == (
+            "not_a_registered_model",
+            [0, 1, 2],
+            2,
+        )
+        with pytest.raises(ValueError, match="explicit observation metadata"):
+            get_observation_metadata(wrapper)
+
+    @patch("ssms.hssm_support.get_model_registry")
+    def test_incomplete_profile_does_not_gain_choices_from_fallback(
+        self, mock_get_registry
+    ):
+        registry = mock_get_registry.return_value
+        registry.has_model.return_value = True
+        registry.get.return_value = {
+            "observation_schema_version": 1,
+            "observation_schema_profile": "legacy_rt_choice",
+        }
+
+        wrapper = get_simulator_fun_internal("incomplete")
+
+        assert validate_simulator_fun(wrapper) == ("incomplete", [0, 1, 2], 2)
+        with pytest.raises(ValueError, match="explicit observation metadata"):
+            get_observation_metadata(wrapper)
+
+    def test_wrapper_choices_do_not_alias_registry_config(self):
+        first = get_simulator_fun_internal("ddm")
+        first.choices.append(99)
+
+        assert get_simulator_fun_internal("ddm").choices == [-1, 1]
 
 
 class TestValidateSimulatorFun:

--- a/tests/test_observation_metadata.py
+++ b/tests/test_observation_metadata.py
@@ -252,13 +252,11 @@ def test_get_observation_metadata_requires_explicit_callable_declaration() -> No
     assert producer.calls == 0
 
 
-def test_get_observation_metadata_resolves_every_registered_model_name() -> None:
-    from ssms.config import get_model_registry
+def test_get_observation_metadata_resolves_every_builtin_model_name() -> None:
+    from ssms.config._modelconfig import get_model_config
 
-    registry = get_model_registry()
-
-    for model_name in registry.list_models():
-        assert _get(model_name) == _validate(registry.get(model_name)), model_name
+    for model_name, config in get_model_config().items():
+        assert _get(model_name) == _validate(config), model_name
 
 
 def test_get_observation_metadata_resolves_derived_deadline_models() -> None:

--- a/tests/test_observation_metadata.py
+++ b/tests/test_observation_metadata.py
@@ -252,6 +252,56 @@ def test_get_observation_metadata_requires_explicit_callable_declaration() -> No
     assert producer.calls == 0
 
 
+def test_get_observation_metadata_resolves_every_registered_model_name() -> None:
+    from ssms.config import get_model_registry
+
+    registry = get_model_registry()
+
+    for model_name in registry.list_models():
+        assert _get(model_name) == _validate(registry.get(model_name)), model_name
+
+
+def test_get_observation_metadata_resolves_derived_deadline_models() -> None:
+    assert _get("ddm_deadline") == _get("ddm")
+
+
+def test_get_observation_metadata_reads_live_registry(monkeypatch) -> None:
+    from ssms.config import get_model_registry
+
+    def simulator() -> None:
+        raise AssertionError("metadata lookup must not execute the simulator")
+
+    registry = get_model_registry()
+    model_name = "test_live_observation_metadata"
+    config = {
+        "name": model_name,
+        "simulator": simulator,
+        **_explicit((RESPONSE,)),
+    }
+    monkeypatch.setitem(registry._configs, model_name, config)
+
+    assert _get(model_name)["observation_schema"] == (RESPONSE,)
+
+
+def test_get_observation_metadata_rejects_unknown_model_names() -> None:
+    with pytest.raises(ValueError, match="Unknown model"):
+        _get("not_a_registered_model")
+
+
+def test_get_observation_metadata_uses_explicit_provider_hook() -> None:
+    class Provider:
+        calls = 0
+
+        def get_observation_metadata(self) -> dict[str, Any]:
+            self.calls += 1
+            return _explicit((RESPONSE,))
+
+    provider = Provider()
+
+    assert _get(provider)["observation_schema"] == (RESPONSE,)
+    assert provider.calls == 1
+
+
 def test_get_observation_metadata_requires_profile_choices_on_callable() -> None:
     class Producer:
         observation_schema_version = 1

--- a/tests/test_simulator_class.py
+++ b/tests/test_simulator_class.py
@@ -228,7 +228,7 @@ class TestSimulation:
         np.testing.assert_array_equal(results1["rts"], results2["rts"])
         np.testing.assert_array_equal(results1["choices"], results2["choices"])
 
-    def test_observation_metadata_access_is_rng_free_and_out_of_band(self):
+    def test_observation_metadata_access_does_not_change_simulation_output(self):
         sim = Simulator("ddm")
         theta = {"v": 0.5, "a": 1.0, "z": 0.5, "t": 0.3}
 

--- a/tests/test_simulator_class.py
+++ b/tests/test_simulator_class.py
@@ -44,6 +44,15 @@ class TestSimulatorInitialization:
         assert sim.config["param_bounds"][0][0] == -4
         assert sim.config["param_bounds"][1][0] == 4
 
+    def test_observation_metadata_is_fresh(self):
+        sim = Simulator("ddm")
+
+        first = sim.get_observation_metadata()
+        first["observation_schema"][0]["name"] = "changed"
+
+        assert sim.get_observation_metadata()["observation_schema"][0]["name"] == "rt"
+        assert sim.config["observation_schema_profile"] == "legacy_rt_choice"
+
     def test_init_with_custom_simulator_function(self):
         """Test initialization with custom simulator function."""
 
@@ -218,6 +227,19 @@ class TestSimulation:
 
         np.testing.assert_array_equal(results1["rts"], results2["rts"])
         np.testing.assert_array_equal(results1["choices"], results2["choices"])
+
+    def test_observation_metadata_access_is_rng_free_and_out_of_band(self):
+        sim = Simulator("ddm")
+        theta = {"v": 0.5, "a": 1.0, "z": 0.5, "t": 0.3}
+
+        before = sim.simulate(theta, n_samples=20, random_state=42)
+        sim.get_observation_metadata()
+        after = sim.simulate(theta, n_samples=20, random_state=42)
+
+        np.testing.assert_array_equal(before["rts"], after["rts"])
+        np.testing.assert_array_equal(before["choices"], after["choices"])
+        assert "observation_schema" not in after["metadata"]
+        assert "observation_schema_version" not in after["metadata"]
 
     def test_lba4_simulation(self):
         """Test plain 4-choice LBA simulation."""


### PR DESCRIPTION
Depends on #339.

## Scope

- resolve explicit observation metadata from registered model names without sampling
- expose a fresh descriptor through `Simulator.get_observation_metadata()`
- attach validated schema declarations to HSSM-compatible simulator wrappers
- resolve supported `*_deadline` variants through the same model-config path as the simulator, preserving exact base-model response labels
- preserve the existing unknown-model warning and fallback behavior

## Compatibility boundary

This is additive, out-of-band metadata. It does not change `simulator()`,
`Simulator.simulate()`, `hssm_sim_wrapper`, result dictionaries, result metadata, or the
three-value `validate_simulator_fun()` contract.

The descriptor's `obs_dim` is semantic and derived from the schema. The existing wrapper
attribute remains a legacy output-width contract. Consequently, a response-only
inverse-temperature-softmax model reports semantic width one while its unchanged HSSM
wrapper still returns the historical two-column dummy-RT/response array.

Metadata lookup remains fail-closed: unknown producers and incomplete declarations do
not acquire schemas from `nchoices`, legacy `obs_dim`, result keys, sampled values, or
the HSSM fallback labels.

## Review hardening

- isolate the built-in metadata census from mutable custom registrations, which may
  intentionally omit schema declarations
- preserve opaque producer-config extensions without deep-copying unrelated runtime
  state; copied response labels and schema declarations remain isolated
- cover binary DDM and LBA deadline variants so direct, class-based, and wrapper
  introspection agree

## Verification

- full package suite: 1,243 passed, 134 skipped
- focused metadata, HSSM-support, registry, and simulator-class suite: 158 passed
- repository-wide Ruff check and format check
- `git diff --check`
- actual deterministic `ddm_deadline` wrapper execution
- HSSM consumer canaries against this worktree: legacy simulator and random-variable
  construction, 2 passed with candidate provenance asserted
- independent static and ecosystem reviews after the deadline and test-order fixes

## Deferred

RLSSM `ModelConfig`/`AssembledModel` adoption, the broader downstream compatibility
matrix, contributor documentation, and any consumer switch to normalized results remain
separate stacked work.
