### PR TITLE
Add angle_extended: an angle variant with drift on (-6, 6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,15 @@ Models, boundary functions, and drift functions are registered in a registry sys
 - `ssms.config.model_config` — CopyOnAccessDict of all 113 model configs (safe to modify)
 - `ModelConfigBuilder.from_model(name, **overrides)` — get/customize a model config
 
+Every entry above is a **consumer** API — how to *read* a config. Authoring one
+goes the other way round: a module under `ssms/config/_modelconfig/` names its
+boundary and drift functions directly (`bf.angle`, `df.gamma_drift`) and is added
+to the `configs` dict in `_modelconfig/__init__.py`. `model_registry.py` builds
+the registry from that dict at import, so a new entry there is registered
+everywhere automatically — reaching for `get_model_registry()` inside a config
+module would bypass the source the registry is built from. See the
+`add-ssm-model` skill for the full workflow.
+
 ### Cython Simulator Layer
 
 Nine `.pyx` simulator modules in `src/cssm/` implement the actual simulators in C:

--- a/ssms/config/_modelconfig/__init__.py
+++ b/ssms/config/_modelconfig/__init__.py
@@ -40,7 +40,7 @@ from .tradeoff import (
     get_tradeoff_weibull_no_bias_config,
 )
 
-from .angle import get_angle_config
+from .angle import get_angle_config, get_angle_extended_config
 from .weibull import get_weibull_config
 from .ddm_par2 import (
     get_ddm_par2_angle_no_bias_config,
@@ -239,6 +239,7 @@ def get_model_config():
         "levy": get_levy_config(),
         "levy_angle": get_levy_angle_config(),
         "angle": get_angle_config(),
+        "angle_extended": get_angle_extended_config(),
         "weibull": get_weibull_config(),
         "gamma_drift": get_gamma_drift_config(),
         "inv_temp_softmax_2": get_inv_temp_softmax_2_config(),
@@ -314,6 +315,7 @@ __all__ = [
     "get_model_config",
     "get_ddm_config",
     "get_angle_config",
+    "get_angle_extended_config",
     "get_weibull_config",
     "get_full_ddm_config",
     "get_ddm_st_config",

--- a/ssms/config/_modelconfig/angle.py
+++ b/ssms/config/_modelconfig/angle.py
@@ -4,6 +4,42 @@ import cssm
 from ssms.basic_simulators import boundary_functions as bf
 
 
+def get_angle_extended_config():
+    """Get the configuration for the Angle model with an extended drift range.
+
+    Identical to `get_angle_config` except that `v` spans (-6, 6) rather than
+    (-3, 3). Same simulator, same boundary, same parameters in the same order --
+    the two configs should stay trivially diffable, so change both together.
+
+    The wider box exists because the published `angle` network was trained on
+    (-3, 3) and cannot be trusted outside it: widening the declared bounds of
+    `angle` itself would let a sampler explore where the network never learned,
+    which fails silently rather than loudly. A separate model earns a separate
+    network.
+
+    Naming follows `shrink_spot_extended`, the registry's other bounds-only
+    variant. Note that one sets its own `"name"` field to `"shrink_spot"`, so
+    its key and name disagree; do not copy that here.
+    """
+    return {
+        "name": "angle_extended",
+        "params": ["v", "a", "z", "t", "theta"],
+        "param_bounds": [[-6.0, 0.3, 0.1, 1e-3, -0.1], [6.0, 3.0, 0.9, 2.0, 1.3]],
+        "boundary_name": "angle",
+        "boundary": bf.angle,
+        "n_params": 5,
+        "default_params": [0.0, 1.0, 0.5, 1e-3, 0.0],
+        "nchoices": 2,
+        "choices": [-1, 1],
+        "n_particles": 1,
+        "simulator": cssm.ddm_flexbound,
+        "parameter_transforms": {
+            "sampling": [],
+            "simulation": [],
+        },
+    }
+
+
 def get_angle_config():
     """Get the configuration for the Angle model."""
     return {

--- a/tests/test_angle_extended_config.py
+++ b/tests/test_angle_extended_config.py
@@ -1,0 +1,110 @@
+"""`angle_extended` is `angle` with a wider drift box and nothing else.
+
+That relationship is the thing worth testing. A structural check that the
+config is well-formed would pass just as happily if someone edited one of the
+two configs and not the other, and the two silently diverging is the failure
+mode a bounds-only variant actually has.
+"""
+
+import numpy as np
+import pytest
+
+from ssms.basic_simulators import Simulator
+from ssms.config._modelconfig import get_model_config
+
+BASE, EXT = "angle", "angle_extended"
+
+
+@pytest.fixture(scope="module")
+def configs():
+    cfg = get_model_config()
+    return cfg[BASE], cfg[EXT]
+
+
+class TestItIsAngleExceptForTheDriftBox:
+    def test_only_the_bounds_differ(self, configs):
+        base, ext = configs
+        # `name` differs by construction; `param_bounds_dict` is derived from
+        # `param_bounds` by `_normalize_param_bounds`, so it differs with it.
+        expected = {"name", "param_bounds", "param_bounds_dict"}
+        differing = {
+            k for k in set(base) | set(ext) if repr(base.get(k)) != repr(ext.get(k))
+        }
+        assert differing == expected, (
+            f"angle_extended diverged from angle in {differing - expected} "
+            "-- the two configs are meant to stay trivially diffable"
+        )
+
+    def test_only_v_moved_and_only_outward(self, configs):
+        base, ext = configs
+        for i, name in enumerate(base["params"]):
+            lo_b, hi_b = base["param_bounds"][0][i], base["param_bounds"][1][i]
+            lo_e, hi_e = ext["param_bounds"][0][i], ext["param_bounds"][1][i]
+            if name == "v":
+                assert (lo_e, hi_e) == (-6.0, 6.0)
+                assert lo_e < lo_b and hi_e > hi_b, "the point is a WIDER box"
+            else:
+                assert (lo_e, hi_e) == (lo_b, hi_b), f"{name} should not have moved"
+
+    def test_the_name_field_and_the_registry_key_agree(self, configs):
+        # `shrink_spot_extended`, the registry's other bounds-only variant,
+        # sets its own "name" to "shrink_spot" -- key and name disagree there.
+        # This asserts we did not inherit that.
+        _, ext = configs
+        assert ext["name"] == EXT
+
+
+class TestTheConfigIsWellFormed:
+    def test_counts_are_consistent(self, configs):
+        _, ext = configs
+        assert len(ext["params"]) == ext["n_params"]
+        assert len(ext["default_params"]) == ext["n_params"]
+        assert len(ext["param_bounds"][0]) == ext["n_params"]
+        assert len(ext["param_bounds"][1]) == ext["n_params"]
+
+    def test_bounds_are_ordered_and_defaults_lie_inside(self, configs):
+        _, ext = configs
+        for name, lo, hi, default in zip(
+            ext["params"], *ext["param_bounds"], ext["default_params"]
+        ):
+            assert lo < hi, f"{name}: lower {lo} >= upper {hi}"
+            assert lo <= default <= hi, (
+                f"{name}: default {default} outside [{lo}, {hi}]"
+            )
+
+
+class TestTheSimulatorReachesTheExtension:
+    def test_default_params_simulate(self, configs):
+        _, ext = configs
+        result = Simulator(model=EXT).simulate(
+            theta=ext["default_params"], n_samples=1000
+        )
+        assert np.asarray(result["rts"]).shape[0] == 1000
+        observed = {
+            int(c) for c in np.asarray(result["choices"]).flatten() if c != -999.0
+        }
+        assert observed.issubset(set(ext["choices"]))
+
+    def test_random_draws_from_the_whole_box_simulate(self, configs):
+        _, ext = configs
+        sim = Simulator(model=EXT)
+        rng = np.random.default_rng(42)
+        for _ in range(5):
+            theta = [rng.uniform(lo, hi) for lo, hi in zip(*ext["param_bounds"])]
+            assert (
+                np.asarray(sim.simulate(theta=theta, n_samples=100)["rts"]).shape[0]
+                == 100
+            )
+
+    @pytest.mark.parametrize("v", [-6.0, -4.0, 4.0, 6.0])
+    def test_the_new_range_behaves_the_way_a_drift_should(self, v):
+        # Not just "does not crash": beyond angle's old +/-3 the choice should
+        # be decided by the sign of v and the RT should be short, which is what
+        # makes this region worth having a network for.
+        result = Simulator(model=EXT).simulate(
+            theta=[v, 1.0, 0.5, 0.3, 0.5], n_samples=2000
+        )
+        rt = np.asarray(result["rts"]).reshape(-1)
+        choices = np.asarray(result["choices"]).reshape(-1)
+        assert (choices > 0).mean() == pytest.approx(1.0 if v > 0 else 0.0, abs=0.02)
+        assert np.median(rt) < 1.0


### PR DESCRIPTION
A collaborator needs `angle` fitted to data whose drift runs past the current ±3 box. The simulator already handles it — `cssm.ddm_flexbound` with the `angle` boundary does not care how large `v` is — so this is a config addition, not new machinery.

```python
angle           v ∈ [-3, 3]
angle_extended  v ∈ [-6, 6]     everything else identical
```

## Why a separate model rather than wider bounds on `angle`

The published `angle.onnx` was trained on `(-3, 3)`. Widening the declared bounds without retraining would let a sampler explore a region the network never saw, where it extrapolates **silently** — no error, just a wrong likelihood. A separate model earns a separate network and leaves `angle` and its published artifact untouched.

## Why this name

`shrink_spot` / `shrink_spot_extended` is the registry's only other bounds-only variant, and `_extended` is its suffix.

Explicitly **not** `angle_drift_ext`, which was the first proposal: in this codebase `drift` names a drift *function*. `base.py` carries a `drift_config` registry, and `gamma_drift` is called that because its `drift_name` **is** `gamma_drift`. A name of that shape sitting next to `gamma_drift_angle` would read as "angle with a custom drift function" — exactly what this is not.

## The tests assert the relationship, not just the shape

Two configs silently diverging is the failure mode a bounds-only variant actually has, so `tests/test_angle_extended_config.py` pins it directly:

- **only `name` and the bounds may differ** between the two configs — a set-difference over every key, so an edit to one and not the other fails here rather than in a training run six weeks later
- **only `v`'s bounds moved, and only outward**
- **`name` equals the registry key.** `get_shrink_spot_extended_config()` sets its own `"name"` to `"shrink_spot"`, so key and name disagree there. This asserts we did not inherit that bug.
- **the new range does something**, not merely "does not crash": past ±3 the choice follows the sign of `v` and RTs stay short — the region worth having a network for.

## Measured while validating

Relevant to whoever trains the network for this:

| | `angle` | `angle_extended` |
|---|---|---|
| uniform draws that are one-sided | 32.3% | **55.3%** |
| RT sd at `v=1` → `v=6` | — | 0.250 → **0.059** |

More than half the new box produces near-deterministic choice behaviour, and the densities there are sharply peaked. Both matter for training volume and for the density gate downstream; neither affects this config.

For calibration: a width-12 drift box is the widest in the registry but not unprecedented in kind — `tradeoff_weibull_no_bias.vl2` already ships `[-4, 4]`.

## Verification

Full `add-ssm-model` skill checklist: config loads, counts consistent, bounds ordered, defaults inside bounds, simulator runs on defaults and on random draws from the full box, choices valid.

`uv run pytest tests/` → **1189 passed, 123 skipped**. `ruff check` and `ruff format --check` clean.

(`tests/test_docs_reference_exports.py` is excluded from that count — it needs `mkdocs`, which is not in the default sync, and it fails to import the same way on `main`.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `angle_extended` model configuration.
  * Expanded the supported drift parameter range from -3 to 3 to -6 to 6.
  * Made the configuration available through the model configuration registry.

* **Tests**
  * Added coverage for configuration validity, default and random simulations, and behavior across the expanded drift range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->