### PR TITLE
Mask omissions on rts, not on choices

### DIFF
--- a/ssms/dataset_generators/pipelines/simulation_pipeline.py
+++ b/ssms/dataset_generators/pipelines/simulation_pipeline.py
@@ -296,8 +296,14 @@ class SimulationPipeline:
         for i, choice in enumerate(possible_choices):
             choice_p[0, i] = np.sum(choices == choice) / n_samples
 
+        # An omitted trial is marked in `rts`, not in `choices`: the simulator
+        # records -999.0 as the reaction time and leaves the latent choice
+        # alone. Masking on `choices` therefore never excludes anything, which
+        # is what made `omission_p` below read zero on every deadline model.
+        omitted = rts == OMISSION_SENTINEL
+
         # Compute choice probabilities excluding omissions
-        non_omitted = choices != OMISSION_SENTINEL
+        non_omitted = ~omitted
         if np.any(non_omitted):
             choices_no_omission = choices[non_omitted]
             n_no_omission = len(choices_no_omission)
@@ -310,14 +316,12 @@ class SimulationPipeline:
             choice_p_no_omission[0, :] = 1.0 / len(possible_choices)
 
         # Compute omission probability
-        omission_p[0, 0] = np.sum(choices == OMISSION_SENTINEL) / n_samples
+        omission_p[0, 0] = np.sum(omitted) / n_samples
 
         # Compute go/nogo probabilities
         # nogo = not choosing max choice OR omission
         max_choice = max(possible_choices)
-        nogo_p[0, 0] = (
-            np.sum((choices != max_choice) | (rts == OMISSION_SENTINEL)) / n_samples
-        )
+        nogo_p[0, 0] = np.sum((choices != max_choice) | omitted) / n_samples
         go_p[0, 0] = 1 - nogo_p[0, 0]
 
         # Compute RT histograms (separated by choice)

--- a/tests/test_omission_labels.py
+++ b/tests/test_omission_labels.py
@@ -1,0 +1,86 @@
+"""Omissions are marked in `rts`, not in `choices`.
+
+The simulator records -999.0 as the reaction time of a trial that ran past its
+deadline and leaves the latent choice alone. Masking on `choices` therefore
+never excludes anything, and `omission_p` read 0.0 on every deadline model --
+so an OPN trained from a deadline corpus would have learned a constant.
+`nogo_p` was unaffected because it already tested `rts`.
+"""
+
+import numpy as np
+import pytest
+
+from ssms.basic_simulators.simulator import simulator
+from ssms.config.model_config_builder import ModelConfigBuilder
+
+OMISSION_SENTINEL = -999.0
+DEADLINE_MODELS = ["ddm_deadline", "angle_deadline", "gamma_drift_angle_deadline"]
+
+
+def _simulate(model, deadline=0.8, n=8000, seed=0):
+    cfg = ModelConfigBuilder.from_model(model)
+    theta = np.array(cfg["default_params"], dtype=float)
+    theta[cfg["params"].index("deadline")] = deadline
+    theta[0] = 1.0  # a drift that resolves, so the deadline is what bites
+    out = simulator(
+        theta=np.tile(theta, (n, 1)), model=model, n_samples=1, random_state=seed
+    )
+    return np.asarray(out["choices"]).ravel(), np.asarray(out["rts"]).ravel()
+
+
+def _labels(choices, rts, possible=(-1, 1)):
+    """Call the label computation directly. It takes `self` but never uses it."""
+    from ssms.dataset_generators.pipelines.simulation_pipeline import SimulationPipeline
+
+    return SimulationPipeline._compute_auxiliary_labels(
+        None,
+        {
+            "choices": choices,
+            "rts": rts,
+            "metadata": {"possible_choices": list(possible)},
+        },
+    )
+
+
+@pytest.mark.parametrize("model", DEADLINE_MODELS)
+def test_the_simulator_marks_omissions_in_rts_not_choices(model):
+    """The premise. If this ever changes, the mask below must change with it."""
+    choices, rts = _simulate(model)
+    assert (rts == OMISSION_SENTINEL).any(), "no omissions: raise the drift or lower d"
+    assert not (choices == OMISSION_SENTINEL).any(), (
+        "choices now carry the sentinel too -- the omission mask needs revisiting"
+    )
+
+
+@pytest.mark.parametrize("model", DEADLINE_MODELS)
+def test_omission_probability_is_not_identically_zero(model):
+    choices, rts = _simulate(model)
+    expected = float((rts == OMISSION_SENTINEL).mean())
+    assert expected > 0.05, "the fixture must actually produce omissions"
+
+    labels = _labels(choices, rts)
+    assert labels["omission_p"][0, 0] == pytest.approx(expected, abs=1e-9)
+
+
+def test_choice_probabilities_excluding_omissions_actually_exclude_them():
+    choices, rts = _simulate("ddm_deadline")
+    labels = _labels(choices, rts)
+    kept = choices[rts != OMISSION_SENTINEL]
+    for i, c in enumerate([-1, 1]):
+        assert labels["choice_p_no_omission"][0, i] == pytest.approx(
+            float((kept == c).mean()), abs=1e-9
+        )
+    # and they must differ from the all-trials version, or the test proves nothing
+    assert not np.allclose(
+        labels["choice_p_no_omission"][0], labels["choice_p"][0], atol=1e-6
+    )
+
+
+def test_nogo_decomposes_into_wrong_choice_plus_omission():
+    """The identity the derived-network plan relies on, checked on real output."""
+    choices, rts = _simulate("gamma_drift_angle_deadline")
+    labels = _labels(choices, rts)
+    omitted = rts == OMISSION_SENTINEL
+    p_min = float(((choices != 1) & ~omitted).mean())
+    p_omit = float(omitted.mean())
+    assert labels["nogo_p"][0, 0] == pytest.approx(p_min + p_omit, abs=1e-9)


### PR DESCRIPTION
The simulator marks a trial that ran past its deadline by writing `-999.0` into **`rts`**, leaving the latent choice alone. Two of the auxiliary labels masked on **`choices`** instead, where the sentinel never appears — so the mask matched nothing.

```python
omission_p           = P(choices == SENTINEL)   ->  0.0, always
choice_p_no_omission   masked on choices        ->  excluded nothing
```

Measured on the shipped deadline models at deadline 0.8, 8000 trials each:

| model | true omission rate | `omission_p` as recorded |
|---|---|---|
| `ddm_deadline` | 0.3511 | **0.0000** |
| `angle_deadline` | 0.3511 | **0.0000** |
| `gamma_drift_deadline` | 0.5429 | **0.0000** |
| `gamma_drift_angle_deadline` | 0.5429 | **0.0000** |

## Why this is more than a mislabel

An **OPN is trained on `omission_p`**. So a deadline data-generation campaign — on the order of 6,500 core-hours per model — would have produced a network trained against a constant zero. Nothing downstream fails loudly: the labels are well-formed, the training converges, the ONNX exports, and the artifact is simply useless.

`nogo_p` was already correct because it tested `rts` as well as `choices`. That inconsistency between neighbouring lines is what made the defect visible. All three now share one `omitted` mask so they cannot drift apart again.

## Tests

- **the premise** — the simulator marks `rts` and not `choices`, on three deadline models. If that ever changes, the mask must change with it, and this fails first.
- **`omission_p` tracks the real rate** rather than reading zero.
- **`choice_p_no_omission` excludes what it claims to**, and differs from the all-trials version — without that second assertion the test would pass on a no-omission fixture and prove nothing.
- **`nogo_p == P(wrong choice, responded) + P(omitted)`**, the identity a derived-network approach depends on, checked against real simulator output.

## Verification

`uv run pytest tests/` → **1197 passed, 123 skipped**. `ruff check` and `ruff format --check` clean.

(`tests/test_docs_reference_exports.py` excluded from that count — it needs `mkdocs`, which is not in the default sync, and fails to import the same way on `main`.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected omission handling for deadline-based trials.
  * Omission probabilities now reflect actual omitted trials.
  * Choice and no-go probabilities now correctly exclude and account for omissions.
* **Tests**
  * Added coverage for omission marking and related probability calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->